### PR TITLE
Add token registration module and modernize utility generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ refresh), see [`docs/ASSESSMENT.md`](docs/ASSESSMENT.md).
 - Zero dependencies – import only the pieces you need.
 - Configurable grid, offset, and breakpoint maps exposed through modern mixins.
 - Helper mixins that generate spacing, colour, border, radius, and container
-utilities.
+  utilities.
 - A ratio-driven typography scale with optional fluid sizing helpers.
 - Layout primitives (`stack`, `cluster`, `auto-grid`, `container`) that cover the
-most common “small-but-clever” patterns found in lean CSS frameworks.
+  most common “small-but-clever” patterns found in lean CSS frameworks.
+- Token registration helpers that emit design tokens as CSS custom properties,
+  including tone variants for every colour helper.
 - Automatic CSS custom properties for colours, radii, and spacing tokens.
 
 ## Getting started
@@ -82,6 +84,17 @@ most common “small-but-clever” patterns found in lean CSS frameworks.
 
 4. Optionally include the helper partials (`_buttons.scss`, etc.) that ship with
    Pier – they already `@use` the settings aggregator.
+
+   ```scss
+   @use "pier/tokens" as tokens;
+
+   // Publish tokens without generating any utility classes.
+   @include tokens.register(".design-system");
+   ```
+
+   The default utility bundle still calls `tokens.register()` internally, but
+   the dedicated module makes it easy to scope or rename the CSS custom
+   properties that Pier emits.
 
 See `source/pier/_utilities.scss` for the utility classes generated out of the
 box, and `source/_buttons.scss` for how the colour helpers compose in practice.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -10,6 +10,7 @@ prefer. All modules live inside `source/pier/`.
 | `pier/mixins` | Core mixins for spacing, borders, radii, typography, and colour utility generation. |
 | `pier/grid` | Flexbox grid mixins plus the `generate-grid()` helper that outputs responsive `.row`, `.col`, and `.offset` classes. |
 | `pier/layout` | Layout primitives: `stack`, `cluster`, `auto-grid`, and `container`. |
+| `pier/tokens` | Emits design tokens as CSS custom properties. Configure scope, prefix, and which token groups to publish. |
 | `pier/utilities` | Generates the default utility classes and publishes tokens as CSS custom properties. |
 
 The quickest way to get started is to create a settings file that configures the
@@ -38,6 +39,25 @@ tokens and forwards the rest of the modules:
 
 @include grid.generate-grid();
 @include utilities.generate-utilities();
+```
+
+`generate-utilities()` now accepts optional parameters for token scope and
+prefixes. To publish tokens inside a wrapper while keeping the default utility
+classes, pass the options through:
+
+```scss
+@include utilities.generate-utilities(
+  $token-scope: ".design-system",
+  $token-prefix: "ds"
+);
+```
+
+If you only need the CSS custom properties, call the token helper directly:
+
+```scss
+@use "pier/tokens" as tokens;
+
+@include tokens.register($prefix: "ds", $include: (colors, spaces));
 ```
 
 In your application styles you can then alias the settings module and call the

--- a/source/_settings.scss
+++ b/source/_settings.scss
@@ -5,6 +5,7 @@
 @forward "pier/mixins";
 @forward "pier/grid";
 @forward "pier/layout";
+@forward "pier/tokens";
 @forward "pier/utilities";
 
 @use "pier/config" as config;

--- a/source/pier.scss
+++ b/source/pier.scss
@@ -3,6 +3,7 @@
 @forward "pier/mixins";
 @forward "pier/grid";
 @forward "pier/layout";
+@forward "pier/tokens";
 @forward "pier/utilities";
 @forward "pier/reset";
 @forward "pier/print";

--- a/source/pier/_tokens.scss
+++ b/source/pier/_tokens.scss
@@ -1,0 +1,133 @@
+@use "sass:list";
+@use "sass:map";
+@use "sass:math";
+@use "sass:meta";
+
+@use "config" as config;
+@use "functions" as fn;
+
+@function _normalise-targets($include) {
+  @if $include == null or $include == all {
+    @return (spaces, radii, colors, fonts, measures, breakpoints);
+  }
+
+  @if meta.type-of($include) != "list" {
+    @return ($include,);
+  }
+
+  @return $include;
+}
+
+@function _should-output($targets, $item) {
+  @return list.index($targets, $item) != null;
+}
+
+@function _color-tones($token) {
+  $tones: (base,);
+
+  @if meta.type-of($token) == "map" {
+    @each $tone in map.keys($token) {
+      @if list.index($tones, $tone) == null {
+        $tones: list.append($tones, $tone);
+      }
+    }
+  }
+
+  @each $tone, $_ in config.$color-steps {
+    @if list.index($tones, $tone) == null {
+      $tones: list.append($tones, $tone);
+    }
+  }
+
+  @return $tones;
+}
+
+@function _color-variable-name($prefix, $name, $tone) {
+  $suffix: "";
+
+  @if $tone != base {
+    $suffix: "-#{$tone}";
+  }
+
+  @return "--#{$prefix}-color-#{$name}#{$suffix}";
+}
+
+@function _container-variable-name($prefix, $name) {
+  @return "--#{$prefix}-container-#{$name}";
+}
+
+@function _breakpoint-variable-name($prefix, $orientation, $name) {
+  @return "--#{$prefix}-breakpoint-#{$orientation}-#{$name}";
+}
+
+@function _normalise-length($value) {
+  @if meta.type-of($value) == "number" and math.is-unitless($value) {
+    @return fn.rem-calc($value);
+  }
+
+  @if meta.type-of($value) == "number" and math.compatible($value, 1px) {
+    @return fn.rem-calc($value);
+  }
+
+  @return $value;
+}
+
+@mixin register(
+  $scope: ":root",
+  $include: all,
+  $prefix: "pier"
+) {
+  $targets: _normalise-targets($include);
+
+  #{$scope} {
+    @if _should-output($targets, spaces) {
+      @each $name, $space in config.$spacers {
+        --#{$prefix}-space-#{$name}: #{$space};
+      }
+    }
+
+    @if _should-output($targets, radii) {
+      @each $name, $radius in config.$radii {
+        --#{$prefix}-radius-#{$name}: #{$radius};
+      }
+    }
+
+    @if _should-output($targets, colors) {
+      @each $name, $token in config.$helpers {
+        $tones: _color-tones($token);
+
+        @each $tone in $tones {
+          #{_color-variable-name($prefix, $name, $tone)}: #{fn.color($name, $tone)};
+        }
+      }
+    }
+
+    @if _should-output($targets, fonts) {
+      @each $name, $_ in config.$fonts {
+        --#{$prefix}-font-#{$name}: #{fn.font-family($name)};
+      }
+      --#{$prefix}-heading-weight: #{config.$heading-weight};
+    }
+
+    @if _should-output($targets, measures) {
+      --#{$prefix}-root-font-size: #{_normalise-length(config.$root-font-size)};
+      --#{$prefix}-column-gutter: #{_normalise-length(config.$column-gutter)};
+      --#{$prefix}-stack-gap: #{_normalise-length(config.$stack-default-gap)};
+      --#{$prefix}-cluster-gap: #{_normalise-length(config.$cluster-default-gap)};
+      --#{$prefix}-cluster-align: #{config.$cluster-align};
+      @each $name, $value in config.$container-widths {
+        #{_container-variable-name($prefix, $name)}: #{_normalise-length($value)};
+      }
+    }
+
+    @if _should-output($targets, breakpoints) {
+      @each $name, $value in config.$breakpoints {
+        #{_breakpoint-variable-name($prefix, width, $name)}: #{_normalise-length($value)};
+      }
+
+      @each $name, $value in config.$vbreakpoints {
+        #{_breakpoint-variable-name($prefix, height, $name)}: #{_normalise-length($value)};
+      }
+    }
+  }
+}

--- a/source/pier/_utilities.scss
+++ b/source/pier/_utilities.scss
@@ -1,10 +1,79 @@
 @use "sass:map";
+@use "sass:meta";
 
 @use "config" as config;
-@use "functions" as fn;
 @use "grid";
 @use "layout";
 @use "mixins";
+@use "tokens";
+
+$utility-config: (
+  border: (
+    module: mixins,
+    name: borders,
+  ),
+  margin: (
+    module: mixins,
+    name: margin,
+  ),
+  padding: (
+    module: mixins,
+    name: padding,
+  ),
+  radius: (
+    module: mixins,
+    name: radii,
+  ),
+  color: (
+    module: mixins,
+    name: colour-set,
+    args: (color),
+  ),
+  hover-color: (
+    module: mixins,
+    name: colour-set,
+    args: (hover, color),
+  ),
+  background: (
+    module: mixins,
+    name: colour-set,
+    args: (background-color),
+  ),
+  border-color: (
+    module: mixins,
+    name: colour-set,
+    args: (border-color),
+  ),
+  surface: (
+    module: mixins,
+    name: colour-set,
+    args: (background-color, (color contrast)),
+  ),
+  flow: (
+    module: layout,
+    name: stack,
+  ),
+  cluster: (
+    module: layout,
+    name: cluster,
+  ),
+  auto-grid: (
+    module: layout,
+    name: auto-grid,
+  ),
+  container: (
+    module: layout,
+    name: container,
+  ),
+);
+
+@mixin _call-utility($config) {
+  $module: map.get($config, module);
+  $name: map.get($config, name);
+  $args: if(map.has-key($config, args), map.get($config, args), ());
+
+  @include meta.call(meta.get-mixin($name, $module: $module), $args...);
+}
 
 @mixin _responsive-scope($breakpoint) {
   @include grid.breakpoint($breakpoint) {
@@ -15,87 +84,32 @@
 }
 
 @mixin _utility-block() {
-  &border {
-    @include mixins.borders();
-  }
-
-  &margin {
-    @include mixins.margin();
-  }
-
-  &padding {
-    @include mixins.padding();
-  }
-
-  &radius {
-    @include mixins.radii();
-  }
-
-  &color {
-    @include mixins.colour-set(color);
-  }
-
-  &hover-color {
-    @include mixins.colour-set(hover, color);
-  }
-
-  &background {
-    @include mixins.colour-set(background-color);
-  }
-
-  &border-color {
-    @include mixins.colour-set(border-color);
-  }
-
-  &surface {
-    @include mixins.colour-set(background-color, (color contrast));
-  }
-
-  &flow {
-    @include layout.stack();
-  }
-
-  &cluster {
-    @include layout.cluster();
-  }
-
-  &auto-grid {
-    @include layout.auto-grid();
-  }
-
-  &container {
-    @include layout.container();
+  @each $name, $config in $utility-config {
+    &#{$name} {
+      @include _call-utility($config);
+    }
   }
 }
 
-@mixin generate-utilities() {
-  :root {
-    @each $name, $space in config.$spacers {
-      --pier-space-#{$name}: #{$space};
-    }
-
-    @each $name, $radius in config.$radii {
-      --pier-radius-#{$name}: #{$radius};
-    }
-
-    @each $name, $color in config.$helpers {
-      --pier-color-#{$name}: #{fn.color($name)};
+@mixin _base-utilities() {
+  @each $name, $config in $utility-config {
+    .#{$name} {
+      @include _call-utility($config);
     }
   }
+}
 
-  .border { @include mixins.borders(); }
-  .margin { @include mixins.margin(); }
-  .padding { @include mixins.padding(); }
-  .radius { @include mixins.radii(); }
-  .color { @include mixins.colour-set(color); }
-  .hover-color { @include mixins.colour-set(hover, color); }
-  .background { @include mixins.colour-set(background-color); }
-  .border-color { @include mixins.colour-set(border-color); }
-  .surface { @include mixins.colour-set(background-color, (color contrast)); }
-  .flow { @include layout.stack(); }
-  .cluster { @include layout.cluster(); }
-  .auto-grid { @include layout.auto-grid(); }
-  .container { @include layout.container(); }
+@mixin generate-utilities(
+  $register-tokens: true,
+  $token-scope: ":root",
+  $token-include: all,
+  $token-prefix: "pier"
+) {
+  @if $register-tokens {
+    @include tokens.register($token-scope, $token-include, $token-prefix);
+  }
+
+  @include _base-utilities();
 
   @each $breakpoint, $settings in config.$grid {
     @if $breakpoint != small {


### PR DESCRIPTION
## Summary
- add a dedicated token module for publishing CSS custom properties with scoped and prefixed output
- refactor utility generation to share configuration data, reducing duplication while exposing token options
- document the new token workflow and forward the module through the primary entry points

## Testing
- Not run (Sass-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f9e103c4988332976393ecc6b809ca