### PR TITLE
feat: expand theming utilities and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,123 @@
 # Pier
 
-> 🚧 A lightweight & tidy Sass framework
+> Light-but-robust Sass primitives for design systems that grow with you.
 
-Pier started life as a personal alternative to larger frameworks such as
-Bootstrap or Tailwind. The framework focuses on a handful of mixins that
-generate grids, spacing helpers, colour variants, and typography rules from a
-single theme map. This refresh modernises the module structure, introduces a
-first-class configuration layer, and ships with a turn-key bundle for rapid
-onboarding.
+Pier is a modular Sass framework that compiles alongside your application. It
+ships layout mixins, theming hooks, form controls, and component tokens without
+forcing a specific runtime. Everything is dependency free and tree-shakeable via
+selective `@use` imports.
 
 ## Quick start
+
+Install directly from GitHub:
 
 ```bash
 npm install github:jmilr/pier
 ```
 
-Import the pre-bundled stylesheet to emit the reset, utilities, grid helpers,
-and button styles in one line:
+Drop the unified entry point into your Sass build, apply the default theme, and
+emit the grid + utility layers:
 
 ```scss
-@use "pier/all";
-```
+@use "pier/_all" as pier;
 
-Prefer to keep the namespace? Alias the package instead:
-
-```scss
-@use "pier" as pier;
-
+@include pier.pier-apply-theme(pier.$pier-theme);
+@include pier.pier-apply-theme(pier.$pier-theme-dark, "[data-theme='dark']");
 @include pier.generate-grid();
 @include pier.generate-utilities();
 ```
 
-## Theme overrides
-
-All configurable values (colours, spacing, fonts, radii, breakpoints) live in a
-single `$pier-theme` map. Override only the keys you care about by calling the
-`pier-theme()` mixin before generating any CSS:
+Need fewer layers? Each module is exported individually so you can opt-in to
+only the pieces you care about:
 
 ```scss
-// _theme.scss
-@use "pier" as *;
-@forward "pier";
-
-@include pier-theme((
-  color-accent: #ff7849,
-  space-unit: 0.75rem,
-  helpers: (
-    brand: #6633ff,
-  ),
-));
-
-@include generate-grid();
-@include generate-utilities();
-```
-
-Now import your theme file from your application stylesheet:
-
-```scss
-@use "theme" as *;
-```
-
-Every config variable also respects `$pier-theme-overrides`, so you can apply
-overrides inline when using the one-line bundle:
-
-```scss
-@use "pier/all" with (
-  $pier-theme-overrides: (
-    radius: 0.75rem,
-    helpers: (primary: #14213d),
-  ),
-);
-```
-
-## CLI helper
-
-Generate the starter `_theme.scss` (shown above) with zero configuration:
-
-```bash
-npx pier init
-```
-
-The script creates the file in your current working directory, includes the
-package import, and adds commented override examples so you can tweak values
-quickly.
-
-## Modular imports
-
-Pier exposes every layer via `@forward` so you can cherry-pick pieces:
-
-```scss
-@use "pier/functions" as fn;
 @use "pier/layout" as layout;
-@use "pier/typography" as type;
+@use "pier/forms.base" as forms;
 
 .my-card {
-  @include layout.stack(fn.spacer(4));
-  font-family: fn.font-family(primary);
-  @include type.size(h3);
+  @include layout.stack(2rem);
+  @include forms.pier-input($variant: filled);
 }
 ```
 
-Prefer to keep bundles lean? Import just the grid utilities without components:
+## Theme overrides and dark mode
+
+All tokens live in the `$pier-theme` maps. Override keys via `@use` configuration
+or merge them manually before applying the theme mixin:
 
 ```scss
-@use "pier/grid";
-@use "pier/utilities" as utilities;
+@use "pier/_all" as pier with (
+  $pier-theme-overrides: (
+    color-accent: #ff7849,
+    space-unit: 0.75rem,
+    components: (
+      button: (font-weight: 700),
+    ),
+  ),
+);
 
-@include grid.generate-grid();
-@include utilities.generate-utilities($register-tokens: false);
+@include pier.pier-apply-theme(pier.$pier-theme);
+@include pier.pier-apply-theme(pier.$pier-theme-dark, "[data-theme='dark']");
 ```
 
-> ⚡️ Performance tip: the `@use "pier/all"` entry point is perfect for
-> prototypes. For production builds, assemble a slimmer bundle by importing
-> individual modules or compiling from `src/pier-core.scss`.
+Switching to dark mode at runtime only requires toggling the `data-theme`
+attribute. Every component reads from CSS custom properties, so the UI updates
+without recompilation:
 
-## Build outputs
+```js
+document.documentElement.dataset.theme = 'dark';
+```
 
-Run the Dart Sass build to emit distributable stylesheets:
+## Optional utilities
+
+Spacing, alignment, and sizing helpers are generated only when their mixins are
+included. Enable or disable them globally by overriding the feature flags in
+`pier/_utilities.scss`:
+
+```scss
+@use "pier/utilities" with (
+  $pier-include-spacing-utilities: false,
+  $pier-include-align-utilities: true,
+);
+```
+
+You can also pull the generators directly:
+
+```scss
+@use "pier/utilities.spacing" as spacing;
+
+@include spacing.pier-spacing-utilities((
+  0: 0,
+  xs: 0.25rem,
+  sm: 0.5rem,
+));
+```
+
+## Bundled builds
+
+The repository ships a couple of ready-made entry points:
+
+- `src/pier-core.scss` – reset, CSS variables, grid, and utilities
+- `src/full.scss` – the complete framework including buttons, forms, tooltips, and layout patterns
+
+Compile them with the provided npm scripts (see below) or wire them into your own
+build tool.
+
+## Build scripts
 
 ```bash
 npm install
-npm run build
+npm run build:css      # dist/pier.css – full, expanded build
+npm run build:css:min  # dist/pier.min.css – minified build
+npm run build:core     # dist/pier-core.css – reset + utilities
+npm run demo           # build CSS and launch the demo
 ```
 
-This produces three files in `dist/`:
+All scripts rely on Dart Sass. Feel free to swap in your own bundler or
+integrate these commands into your existing pipeline.
 
-- `pier.css` – full bundle (reset, utilities, buttons)
-- `pier.min.css` – minified full bundle
-- `pier-core.css` – reset + utilities without components
+## Documentation
 
-## Further reading
-
-- [`docs/architecture.md`](docs/architecture.md) – overview of the Sass layers
-- [`docs/USAGE.md`](docs/USAGE.md) – additional recipes and legacy guidance
-- [`docs/ASSESSMENT.md`](docs/ASSESSMENT.md) – audit of the original source
+- [`docs/architecture.md`](docs/architecture.md) – layer stack and forwarding strategy
+- [`docs/demo.md`](docs/demo.md) – build and explore the living demo
+- [`docs/USAGE.md`](docs/USAGE.md) – legacy recipes and additional guidance

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,54 +1,71 @@
 # Pier architecture
 
-Pier is organised into small, explicit Sass modules so you can opt in to only
-the layers you need. Each layer builds on the previous one and is exposed via
-`@forward` through the package entry point.
+Pier is organised into explicit Sass modules so you can opt in to only the
+layers you need. Everything resolves back to the `$pier-theme` map declared in
+`src/pier/_theme.config.scss`, and every layer is exported through
+`src/_all.scss` for one-line imports.
 
-## Config
+## Configuration & tokens
 
-Defined in `src/pier/_theme.config.scss` and `src/pier/_config.scss`. The theme
-config file declares the `$pier-theme` map and the `pier-theme()` mixin that
-merges overrides. The config module resolves values from that map and exposes
-traditional Sass variables (e.g. `$breakpoints`, `$spacers`, `$fonts`) for the
-rest of the toolkit.
+- `src/pier/_theme.config.scss` – defines `$pier-theme` and `$pier-theme-dark`,
+  plus the `pier-apply-theme()` mixin that emits CSS variables for both base and
+  component tokens.
+- `src/pier/_config.scss` – resolves theme values into traditional Sass
+  variables (`$breakpoints`, `$spacers`, `$fonts`, etc.).
+- `src/pier/_tokens.scss` – the `register()` mixin mirrors those tokens into CSS
+  custom properties so runtime theme switching works without recompilation.
 
-## Tokens
+## Functions & states
 
-`src/pier/_tokens.scss` contains the `register()` mixin, which emits CSS custom
-properties for colours, spacing units, radii, fonts, and breakpoints. Utility
-layers call this mixin automatically, but you can also invoke it directly to
-scope tokens or change the variable prefix.
-
-## Core
-
-Core functionality lives in `src/pier/_functions.scss` and `src/pier/_mixins.scss`.
-These files expose the math helpers, colour lookups, breakpoint mixins, and
-spacing/colour generators that power the rest of Pier. The typography re-export
-(`src/pier/_typography.scss`) forwards the font-related mixins for convenient
-consumption.
+- `src/pier/_functions.scss` – colour helpers, spacing utilities, and math
+  helpers.
+- `src/pier/_mixins.scss` – breakpoint wrappers and the generators used by the
+  utility layer.
+- `src/pier/_states.scss` – shared focus-ring and interaction mixins plus the
+  `.is-*` state classes consumed by buttons and inputs.
 
 ## Layout
 
-`src/pier/_layout.scss` provides composable primitives (`stack`, `cluster`,
-`auto-grid`, `container`, `bleed`) that can be used directly or through the
-utility generator. They rely on the config layer for spacing, radii, and
-breakpoint values.
+- `src/pier/_layout.scss` – mixins for `stack`, `cluster`, `sidebar`, `nav`, and
+  `cover` patterns.
+- `src/pier/_layout.patterns.scss` – class-backed versions of those mixins using
+  CSS custom properties for runtime control.
+- `src/pier/_grid.scss` – `generate-grid()` still ships responsive column and
+  offset helpers.
+
+## Typography
+
+- `src/pier/_typography.scss` – base element styles wired to the fluid type
+  scale.
+- `src/pier/_typography.roles.scss` – roles (`.lead`, `.small`, `.muted`,
+  `.mono`) plus the `pier-text()` mixin for custom slots.
 
 ## Components
 
-Lightweight component styles reside in `src/pier/_buttons.scss`. The bundled
-build includes these by default, but you can opt out by compiling from
-`src/pier-core.scss` instead.
-
-## Helpers
-
-Utility helpers that don't warrant a dedicated module live in
-`src/pier/_helpers.scss`. They provide conveniences such as `visually-hidden`
-and `clearfix` that can be mixed into components as needed.
+- `src/pier/_components.tokens.scss` – maps theme tokens to component-specific
+  CSS custom properties (buttons, inputs, cards, tooltips).
+- `src/pier/_buttons.scss` – semantic button classes with size/state variants.
+- `src/pier/_forms.base.scss`, `_forms.inline.scss`, `_forms.feedback.scss` –
+  input primitives, inline groups, and validation states.
+- `src/pier/_icons.scss` – icon utility classes and placement mixin.
+- `src/pier/_tooltips.scss` – attribute-driven tooltip pattern.
 
 ## Utilities
 
-`src/pier/_utilities.scss` wires everything together. Its `generate-utilities()`
-mixin outputs Pier's spacing, border, colour, and layout helper classes, as well
-as breakpoint-scoped variants. The `src/all.scss` entry point runs this mixin to
-produce the default utility bundle.
+- `src/pier/_utilities.scss` – `generate-utilities()` orchestrates spacing,
+  colour, and layout helpers. Feature flags allow spacing/alignment/sizing
+  utilities to be toggled.
+- `src/pier/_utilities.spacing.scss`, `_utilities.align.scss`,
+  `_utilities.sizing.scss` – mixins that output each optional utility set.
+
+## Entry points
+
+- `src/_all.scss` – unified forwarder so `@use "pier/_all" as *;` exposes every
+  mixin and class.
+- `src/pier-core.scss` – reset + utilities (no components) with both themes
+  applied.
+- `src/full.scss` – full bundle used by the demo and distributable builds.
+
+When adding a new pattern, place the mixin in the appropriate layer and forward
+it through `src/_all.scss`. Components should read from the theme maps or
+existing CSS variables to stay compatible with light/dark themes.

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,40 @@
+# Demo playground
+
+The repository ships an `index.html` that doubles as a living style guide. It
+exercises the layout patterns, form controls, utilities, and theme switching in
+one place.
+
+## Build the CSS
+
+Compile the full bundle and copy it to `dist/pier.css`:
+
+```bash
+npm install
+npm run build:css
+```
+
+This runs Dart Sass against `src/full.scss`, applying both light and dark themes
+and generating the utility layers.
+
+## View the demo
+
+Open `index.html` in your browser after running the build. A few tips:
+
+- Toggle the "Toggle theme" button to flip between light and dark tokens.
+- Hover and focus the tooltip examples to see the pure CSS pattern.
+- Adjust spacing utilities in the "Utilities" section to confirm optional layers
+  are compiling correctly.
+- Keyboard navigation highlights buttons and inputs with the shared focus ring.
+
+If you are serving the demo via a local web server, the footer will pull the
+version number from `package.json`. When opening directly from the file system
+that fetch is skipped silently.
+
+## Troubleshooting
+
+- **Sass cannot resolve `pier/_all`.** Ensure your Sass load paths include
+  `src/` or import via a relative path.
+- **No utilities are generated.** Check that the feature flags in
+  `pier/_utilities.scss` are enabled or include the dedicated utility mixins.
+- **Dark mode has no effect.** Verify the theme mixin is applied to both
+  `:root` and `[data-theme='dark']` in your compiled stylesheet.

--- a/index.html
+++ b/index.html
@@ -1,162 +1,355 @@
-<html>
-	<head>
-		<meta charset="utf-8">
-		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta name="viewport" content="width=device-width,  initial-scale=1,  user-scalable=no">
-		
-		<link rel="stylesheet" type="text/css" href="/dist/css/main.css">
-	</head>
-	<body>
-	<header id="header" class="row">
-		<div id="logo" class="column medium-4 large-2">
-			<a href="/">
-				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 399.6 139">
-					<title>Pier Logo</title>
-						<path d="M70.69, 0C17.67, 0, 0, 17.44, 0, 69.88, 0, 114, 12.49, 133.31, 48, 138.36l1.49.2c1.27.16, 2.59.31, 3.92.44L65.05, 69.88H47.13l-8.19, 48.57a28.11, 28.11, 0, 0, 1-11-6.32c-3.25-3.21-5.64-7.73-7.32-13.81-2-7.24-3-16.54-3-28.44s1-21.21, 3-28.45c1.68-6.07, 4.07-10.59, 7.32-13.8s7.82-5.57, 14-7.23c7.32-2, 16.73-2.93, 28.76-2.93s21.45, 1, 28.77, 2.93c6.15, 1.66, 10.72, 4, 14, 7.23s5.64, 7.73, 7.32, 13.8c2, 7.24, 3, 16.55, 3, 28.45s-1, 21.2-3, 28.44c-1.68, 6.08-4.07, 10.6-7.32, 13.81a28.11, 28.11, 0, 0, 1-11, 6.32L94.26, 69.88H76.34L88, 139c1.64-.16, 3.3-.35, 4.85-.57l2.2-.32c34.23-5.41, 46.34-24.83, 46.34-68.23C141.39, 17.44, 123.72, 0, 70.69, 0Z" style="fill:#fcfffe"/>
-						<path d="M225.86, 56.81a13.39, 13.39, 0, 0, 1-3.51, 9.5q-3.51, 3.75-10, 3.76H195.26V43.42h17.08q6.51, 0, 10, 3.76A13.56, 13.56, 0, 0, 1, 225.86, 56.81ZM212.34, 25.56H177.41v89.27h17.85V87.92h17.08A32.9, 32.9, 0, 0, 0, 225, 85.56a29.9, 29.9, 0, 0, 0, 9.89-6.5, 30.27, 30.27, 0, 0, 0, 6.5-9.82, 32.12, 32.12, 0, 0, 0, 2.36-12.43, 32.58, 32.58, 0, 0, 0-2.36-12.5A29.29, 29.29, 0, 0, 0, 225, 27.92, 32.9, 32.9, 0, 0, 0, 212.34, 25.56Zm59.3, 25.51H254.81v63.76h16.83ZM252.52, 32.83a10.46, 10.46, 0, 0, 0, 10.71, 10.71, 10.58, 10.58, 0, 0, 0, 7.71-3.06, 10.28, 10.28, 0, 0, 0, 3.12-7.65A10.67, 10.67, 0, 0, 0, 263.23, 22a10.28, 10.28, 0, 0, 0-7.65, 3.13A10.58, 10.58, 0, 0, 0, 252.52, 32.83Zm77, 43H300.89a14.19, 14.19, 0, 0, 1, 15-12q6.12, 0, 9.56, 3.38A14, 14, 0, 0, 1, 329.57, 75.81ZM283.8, 83a37.47, 37.47, 0, 0, 0, 2.3, 13.26, 29.73, 29.73, 0, 0, 0, 6.69, 10.58, 31.18, 31.18, 0, 0, 0, 10.78, 7, 38.5, 38.5, 0, 0, 0, 14.4, 2.55q9.18, 0, 15.3-2.55a38.74, 38.74, 0, 0, 0, 10.07-5.87l-7-13.9a26.09, 26.09, 0, 0, 1-7.84, 4.72, 27.81, 27.81, 0, 0, 1-10.26, 1.78, 22.22, 22.22, 0, 0, 1-5.55-.7, 16, 16, 0, 0, 1-5-2.23, 16.35, 16.35, 0, 0, 1-4-3.82, 14.72, 14.72, 0, 0, 1-2.49-5.49l-.12-.25h46.91V83.46a43, 43, 0, 0, 0-2.16-14, 29.9, 29.9, 0, 0, 0-6.25-10.71A28, 28, 0, 0, 0, 329.57, 52a34.17, 34.17, 0, 0, 0-13.13-2.42, 34.71, 34.71, 0, 0, 0-13.58, 2.55, 29.44, 29.44, 0, 0, 0-10.26, 7.08, 31.87, 31.87, 0, 0, 0-6.5, 10.64A37.12, 37.12, 0, 0, 0, 283.8, 83Zm91.45-21.43V51.07H359.06v63.76h16.83V86q0-9.18, 3.82-13.84T392, 67.52a38.87, 38.87, 0, 0, 1, 3.95.19, 15.4, 15.4, 0, 0, 1, 3.7.83V50.43c-1-.25-2-.47-3-.64a19.08, 19.08, 0, 0, 0-3.25-.25, 18.48, 18.48, 0, 0, 0-11.15, 3.19A21.51, 21.51, 0, 0, 0, 375.25, 61.52Z" style="fill:#fd4732;"/>
-				</svg>
-			</a>
-		</div>
-	</header>
-	<div id="content" class="row">
-		<div class="column">			
-			<h1 class="divider-below">Pier</h1>
-			<h1>Heading One</h1>
-			<h2>Heading Two</h2>
-			<h3>Heading Three</h3>
-			<h4>Heading Four</h4>
-			<h5 class="divider-below">Heading Five</h5>
-			
-			<ul><li>List item one</li><li>List item two</li><li>List item three
-			<ul><li>List sub-item&nbsp;one</li><li>List sub-item&nbsp;two</li><li>List sub-item three</li></ul></li><li>List item four</li><li>List item five</li></ul>
-			
-			<ol><li>Numbered list item one</li><li>Numbered list item two</li><li>Numbered list item three
-			<ol><li>Numbered list sub-item one</li><li>Numbered list sub-item two<ol><li>Numbered list sub-sub-item one</li><li>Numbered list sub-sub-item two</li></ol></li></ol></li><li>Numbered list item four</li></ol>
-			
-			<blockquote>This is a blockquote example to test the styling of blockquotes</blockquote>
-			
-			<h5>Code display:</h5>
-			
-<pre>
-$('.download-link').on('click', '.dropdown-toggle',  function(e){
-    $(this).toggleClass('open');
-    $($(this).attr('href')).toggleClass('collapse');
-    $('.dropdown-menu.collapse').each(function(){
-        var subHeight = $(".archiveGroup",  this).outerHeight();
-        $(this).css("max-height", subHeight + "px");
-    });
-    e.preventDefault();
-});
-</pre>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Pier UI System</title>
+    <link rel="stylesheet" href="dist/pier.css" />
+    <style>
+      :root {
+        color-scheme: light;
+      }
 
-			<p><a href="https://www.vocus.com.au/#entry:2:url">Link styling &mdash; <span data-tooltip="Tooltips!">with tooltips!</span></a></p>
-			
-			<table>
-				<thead>
-					<tr>
-						<th class="background warning">Heading One</th>
-						<th class="background secondary">Heading Two</th>
-						<th class="background success">Heading Three</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>Cell One</td>
-						<td>Cell Two</td>
-						<td>Cell Three</td>
-					</tr>
-				</tbody>
-			</table>
-			
-			<table>
-				<thead>
-					<tr>
-						<th class="background warning">Heading One</th>
-						<th class="background secondary">Heading Two</th>
-						<th class="background success">Heading Three</th>
-					</tr>
-				</thead>
-			</table>
+      body {
+        margin: 0;
+      }
 
-		</div>
-	</div>
-	<div class="row">
-		<div class="column small-6">
-			<p class="group wrap">
-				<a href="#" class="btn secondary large">Button</a>
-				<a class="btn warning large">Button</a>
-				<a class="btn success large">Button</a>
-				<a class="btn danger large">Button</a>
-			</p>
-			<p class="group">
-				<a class="btn warning inverted">Button</a>
-				<a class="btn secondary inverted">Button</a>
-				<a class="btn danger inverted">Button</a>
-			</p>
-			<pre>foo bar baz</pre>
-		</div>
-		<div class="column small-6">
-			<p class="group">
-				<input class="btn base inverted large" placeholder="Input"></input>
-				<a class="btn base large">Submit</a>
-			</p>
-			<p>
-				<a class="btn primary large stretch">Button</a>
-			</p>
-			<p>
-				<a class="btn secondary large">Button</a>
-				<a class="btn danger large">Button</a>
-			</p>
-			<p>
-				<a class="btn warning large">Button</a>
-				<a class="btn success large">Button</a>
-				<a class="btn default large">Button</a>
-			</p>
-			<p>
-				<a class="btn primary">Button</a>
-				<a class="btn secondary">Button</a>
-				<a class="btn danger">Button</a>
-			</p>
-			<p>
-				<a class="btn warning">Button</a>
-				<a class="btn success">Button</a>
-				<a class="btn default">Button</a>
-			</p>
-			<p>
-				<a class="btn primary small">Button</a>
-				<a class="btn secondary small">Button</a>
-				<a class="btn danger small">Button</a>
-			</p>
-			<p>
-				<a class="btn warning small">Button</a>
-				<a class="btn success small">Button</a>
-				<a class="btn default small">Button</a>
-			</p>
-		</div>
-	</div>
-	<div class="row">
-		<div class="column small-6 medium-3">
-			<p>
-				<a class="btn secondary large stretch">Button</a>
-			</p>
-		</div>
-		<div class="column small-6 medium-3">
-			<p>
-				<a class="btn secondary large stretch">Button</a>
-			</p>
-		</div>
-		<div class="column medium-6">
-			<p>
-				<a class="btn secondary large stretch">Button</a>
-			</p>
-		</div>
-		<div class="column">
-			<pre>&lt;div class=&quot;column small-6 medium-3&quot;&gt;
-	&lt;p&gt;
-		&lt;a class=&quot;btn primary large stretch&quot;&gt;Button&lt;/a&gt;
-	&lt;/p&gt;
-&lt;/div&gt;</pre>
-		</div>
-	</div>
-	</body>
+      .demo-shell {
+        min-height: 100vh;
+      }
+
+      .demo-section {
+        padding: clamp(2rem, 4vw, 4rem) 0;
+      }
+
+      .demo-card {
+        background: var(--pier-card-bg);
+        color: var(--pier-card-fg);
+        border: var(--pier-card-border);
+        border-radius: var(--pier-card-radius);
+        box-shadow: var(--pier-card-shadow);
+        padding: var(--pier-card-padding);
+      }
+
+      .swatch {
+        width: 6rem;
+        height: 6rem;
+        border-radius: var(--pier-radius-base);
+        box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+      }
+
+      table.demo-table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      table.demo-table th,
+      table.demo-table td {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid var(--pier-color-border);
+        text-align: left;
+      }
+
+      .demo-utilities .box {
+        background: var(--pier-color-surface);
+        border: 1px dashed var(--pier-color-border);
+        border-radius: var(--pier-radius-base);
+        padding: 1rem;
+      }
+
+      .hero {
+        background: linear-gradient(135deg, rgba(236, 108, 47, 0.1), rgba(236, 108, 47, 0));
+        border-radius: var(--pier-radius-lg);
+        padding: clamp(3rem, 8vw, 6rem);
+      }
+
+      .theme-toggle {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      [data-theme="dark"] {
+        color-scheme: dark;
+      }
+    </style>
+  </head>
+  <body class="demo-shell">
+    <div class="stack" style="--stack-gap: clamp(2rem, 4vw, 4rem);">
+      <section class="demo-section container">
+        <div class="stack" style="--stack-gap: clamp(1.5rem, 3vw, 2.5rem);">
+          <header class="hero stack" style="--stack-gap: clamp(1rem, 2vw, 1.5rem);">
+            <div class="cluster" style="--cluster-align: space-between;">
+              <div class="stack" style="--stack-gap: 0.5rem;">
+                <span class="mono muted">Pier Sass framework</span>
+                <h1>Lightweight primitives for enduring design systems</h1>
+                <p class="lead">Pier ships mixins, layout patterns, and UI components that compile with your Sass build. Import one file for the full experience or cherry-pick only what you need.</p>
+              </div>
+              <button class="btn btn--subtle" id="theme-toggle" type="button">
+                Toggle theme
+              </button>
+            </div>
+            <div class="stack" style="--stack-gap: 0.75rem;">
+              <code class="mono">@use "pier/_all" as *;</code>
+              <code class="mono">@include pier-apply-theme($pier-theme);</code>
+            </div>
+          </header>
+
+          <div class="stack" style="--stack-gap: clamp(1.5rem, 3vw, 2.5rem);">
+            <h2>Theme swatches</h2>
+            <div class="cluster" style="--cluster-gap: clamp(1rem, 2vw, 2rem); --cluster-align: flex-start;">
+              <div class="stack" style="--stack-gap: 0.5rem; align-items: center;">
+                <span class="swatch" style="background: var(--pier-color-bg);"></span>
+                <span class="small muted mono">Background</span>
+              </div>
+              <div class="stack" style="--stack-gap: 0.5rem; align-items: center;">
+                <span class="swatch" style="background: var(--pier-color-surface);"></span>
+                <span class="small muted mono">Surface</span>
+              </div>
+              <div class="stack" style="--stack-gap: 0.5rem; align-items: center;">
+                <span class="swatch" style="background: var(--pier-color-accent);"></span>
+                <span class="small muted mono">Accent</span>
+              </div>
+              <div class="stack" style="--stack-gap: 0.5rem; align-items: center;">
+                <span class="swatch" style="background: var(--pier-color-success);"></span>
+                <span class="small muted mono">Success</span>
+              </div>
+              <div class="stack" style="--stack-gap: 0.5rem; align-items: center;">
+                <span class="swatch" style="background: var(--pier-color-warning);"></span>
+                <span class="small muted mono">Warning</span>
+              </div>
+              <div class="stack" style="--stack-gap: 0.5rem; align-items: center;">
+                <span class="swatch" style="background: var(--pier-color-danger);"></span>
+                <span class="small muted mono">Danger</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo-section container stack" style="--stack-gap: clamp(2rem, 4vw, 3rem);">
+        <header class="stack" style="--stack-gap: 0.75rem;">
+          <h2>Typography</h2>
+          <p class="muted">Fluid type powered by clamp() and the <code class="mono">pier-text</code> mixin. Roles for lead copy, small text, and code provide consistent rhythm.</p>
+        </header>
+        <article class="stack" style="--stack-gap: 1.5rem;">
+          <div class="stack" style="--stack-gap: 0.5rem;">
+            <h1>Display heading</h1>
+            <h2>Section heading</h2>
+            <h3>Sub heading</h3>
+            <h4>Supporting heading</h4>
+            <h5>Minor heading</h5>
+            <h6>Eyebrow</h6>
+          </div>
+          <p class="lead">Pier keeps defaults human sized so you can ship without tuning every variable. The lead class uses relaxed line height and the accent display family.</p>
+          <p>Regular body copy inherits the fluid scale. Use the <code class="mono">.muted</code> role for de-emphasised text and <code class="mono">.mono</code> for inline code like <code class="mono">npm run build:css</code>.</p>
+          <p class="small">Small text helps with captions and legal copy. The mixin accepts size, weight, line height, and tracking tokens.</p>
+          <pre><code>body { @include pier-text(md); }
+code { @include pier-text(sm, $line: 1.6); }</code></pre>
+        </article>
+      </section>
+
+      <section class="demo-section container stack" style="--stack-gap: clamp(2rem, 4vw, 3rem);">
+        <h2>Layout primitives</h2>
+        <div class="stack" style="--stack-gap: 1.5rem;">
+          <div class="demo-card stack" style="--stack-gap: 1rem;">
+            <h3 class="mono">.stack</h3>
+            <div class="stack" style="--stack-gap: 1rem;">
+              <div class="demo-card" style="background: none; border: 1px dashed var(--pier-color-border);">Stacked item one</div>
+              <div class="demo-card" style="background: none; border: 1px dashed var(--pier-color-border);">Stacked item two</div>
+              <div class="demo-card" style="background: none; border: 1px dashed var(--pier-color-border);">Stacked item three</div>
+            </div>
+          </div>
+          <div class="demo-card stack" style="--stack-gap: 1rem;">
+            <h3 class="mono">.cluster</h3>
+            <div class="cluster" style="--cluster-gap: 1rem; --cluster-align: flex-start;">
+              <span class="btn btn--subtle">Tag</span>
+              <span class="btn btn--subtle">Cluster</span>
+              <span class="btn btn--subtle">Wraps</span>
+              <span class="btn btn--subtle">Nicely</span>
+            </div>
+          </div>
+          <div class="demo-card stack" style="--stack-gap: 1rem;">
+            <h3 class="mono">.sidebar</h3>
+            <div class="sidebar" style="--sidebar-side: 35%; --sidebar-gap: 1.5rem;">
+              <div class="stack" style="--stack-gap: 0.75rem;">
+                <h4>Primary column</h4>
+                <p>Use the sidebar pattern for documents with a persistent aside. Set <code class="mono">--sidebar-side</code> for custom ratios.</p>
+              </div>
+              <div class="stack" style="--stack-gap: 0.75rem;">
+                <h4>Secondary</h4>
+                <p class="muted">On small screens this collapses into a vertical stack.</p>
+              </div>
+            </div>
+          </div>
+          <div class="demo-card cover" style="--cover-min: 40vh;">
+            <div class="stack" style="--stack-gap: 0.75rem; text-align: center;">
+              <h3>Cover layout</h3>
+              <p>Center any content block both vertically and horizontally. Perfect for hero panels and callouts.</p>
+              <button class="btn btn--lg">Primary call to action</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="demo-section container stack" style="--stack-gap: clamp(1.5rem, 3vw, 2.5rem);">
+        <h2>Buttons</h2>
+        <div class="cluster" style="--cluster-gap: 1rem; --cluster-align: flex-start;">
+          <button class="btn">Primary</button>
+          <button class="btn btn--subtle">Subtle</button>
+          <button class="btn btn--outline">Outline</button>
+          <button class="btn btn--ghost">Ghost</button>
+          <button class="btn is-loading" aria-live="polite">Loading</button>
+          <button class="btn is-disabled" disabled>Disabled</button>
+        </div>
+        <div class="cluster" style="--cluster-gap: 1rem; --cluster-align: flex-start;">
+          <button class="btn btn--sm">Small</button>
+          <button class="btn">Medium</button>
+          <button class="btn btn--lg">Large</button>
+          <button class="btn is-active">Active state</button>
+        </div>
+      </section>
+
+      <section class="demo-section container stack" style="--stack-gap: clamp(1.5rem, 3vw, 2.5rem);">
+        <h2>Forms</h2>
+        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: clamp(1rem, 2vw, 2rem);">
+          <form class="stack" style="--stack-gap: 1rem;">
+            <div class="field">
+              <label class="label" for="name">Name</label>
+              <input id="name" class="input" placeholder="Jane Doe" />
+              <p class="help">Outline variant with default spacing.</p>
+            </div>
+            <div class="field">
+              <label class="label" for="email">Email</label>
+              <input id="email" type="email" class="input input--filled" placeholder="name@example.com" />
+            </div>
+            <div class="field">
+              <label class="label" for="message">Message</label>
+              <textarea id="message" class="textarea" rows="4" placeholder="Tell us a bit more"></textarea>
+            </div>
+            <div class="cluster" style="--cluster-gap: 0.75rem; --cluster-align: flex-start;">
+              <label class="checkbox">
+                <input type="checkbox" checked />
+                <span>Subscribe to newsletter</span>
+              </label>
+              <label class="radio">
+                <input type="radio" name="contact" checked />
+                <span>Email</span>
+              </label>
+              <label class="radio">
+                <input type="radio" name="contact" />
+                <span>Phone</span>
+              </label>
+            </div>
+            <label class="switch">
+              <input type="checkbox" checked />
+              <span>Enable notifications</span>
+            </label>
+            <label class="stack" style="--stack-gap: 0.5rem;">
+              Range input
+              <input type="range" class="range" />
+            </label>
+          </form>
+
+          <form class="stack" style="--stack-gap: 1rem;">
+            <div class="field is-valid">
+              <label class="label" for="username">Username</label>
+              <input id="username" class="input is-valid" value="pier" />
+              <span class="field__message">Looks great!</span>
+            </div>
+            <div class="field is-warning">
+              <label class="label" for="password">Password</label>
+              <div class="input-group">
+                <span class="input-group__icon input-group__icon--left">🔒</span>
+                <input id="password" type="password" class="input input--with-btn" placeholder="••••••" />
+                <button type="button" class="btn btn--ghost input-group__btn">Reveal</button>
+              </div>
+              <span class="field__message">Use at least eight characters.</span>
+            </div>
+            <div class="field is-invalid">
+              <label class="label" for="select">Select</label>
+              <select id="select" class="select is-invalid">
+                <option>Pick an option</option>
+              </select>
+              <span class="field__message">Required field.</span>
+            </div>
+            <div class="field">
+              <label class="label" for="file">Upload</label>
+              <div class="file">
+                <span class="icon">📁</span>
+                <span class="muted">Drag a file or click to browse</span>
+                <input id="file" type="file" />
+              </div>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section class="demo-section container stack demo-utilities" style="--stack-gap: clamp(1.5rem, 3vw, 2.5rem);">
+        <h2>Utilities</h2>
+        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); gap: clamp(1rem, 2vw, 2rem);">
+          <div class="box m-3">
+            <p class="mono">Spacing utilities</p>
+            <p class="muted">Use <code class="mono">m-*</code>, <code class="mono">p-*</code>, and <code class="mono">gap-*</code> classes to set consistent spacing.</p>
+          </div>
+          <div class="box flex items-center justify-between p-3">
+            <span class="mono">Alignment helpers</span>
+            <span class="btn btn--subtle">Aligned</span>
+          </div>
+          <div class="box stack" style="--stack-gap: 0.5rem;">
+            <p class="mono">Sizing</p>
+            <div class="w-50" style="background: rgba(236, 108, 47, 0.15); padding: 0.5rem;">.w-50</div>
+            <div class="max-w-prose" style="background: rgba(236, 108, 47, 0.08); padding: 0.5rem;">.max-w-prose keeps text readable.</div>
+          </div>
+        </div>
+        <p class="muted small">Utilities compile only when their partials are imported. Disable the feature flags in <code class="mono">pier/_utilities.scss</code> to tree-shake them.</p>
+      </section>
+
+      <section class="demo-section container stack" style="--stack-gap: clamp(1.5rem, 3vw, 2.5rem);">
+        <h2>Tooltips</h2>
+        <div class="cluster" style="--cluster-gap: 1.5rem; --cluster-align: flex-start;">
+          <button class="btn" data-tooltip="Top tooltip">Top</button>
+          <button class="btn" data-tooltip="Right tooltip" data-tooltip-pos="right">Right</button>
+          <button class="btn" data-tooltip="Bottom tooltip" data-tooltip-pos="bottom">Bottom</button>
+          <button class="btn" data-tooltip="Left tooltip" data-tooltip-pos="left">Left</button>
+        </div>
+        <p class="muted small">Tooltips are CSS-only. Reduced motion preferences disable transitions.</p>
+      </section>
+
+      <section class="demo-section container stack" style="--stack-gap: 1.5rem;">
+        <h2>Accessibility & states</h2>
+        <div class="cluster" style="--cluster-gap: 1rem; --cluster-align: flex-start;">
+          <button class="btn" data-tooltip="Focus me and press tab">Keyboard focus</button>
+          <button class="btn is-hovered">.is-hovered</button>
+          <button class="btn is-active">.is-active</button>
+          <button class="btn is-disabled" disabled>.is-disabled</button>
+        </div>
+        <p class="small muted">Focus rings respect <code class="mono">prefers-reduced-motion</code> and colour tokens for each theme.</p>
+      </section>
+
+      <footer class="demo-section container stack" style="--stack-gap: 0.75rem;">
+        <p class="mono muted">Pier version <span id="version">0.2.0</span></p>
+        <p class="small muted">Toggle dark mode to see component tokens rehydrate instantly.</p>
+      </footer>
+    </div>
+
+    <script>
+      const toggle = document.getElementById('theme-toggle');
+      const versionEl = document.getElementById('version');
+      fetch('package.json')
+        .then((response) => response.json())
+        .then((pkg) => {
+          if (pkg && pkg.version && versionEl) {
+            versionEl.textContent = pkg.version;
+          }
+        })
+        .catch(() => {});
+
+      toggle?.addEventListener('click', () => {
+        const root = document.documentElement;
+        const isDark = root.getAttribute('data-theme') === 'dark';
+        root.setAttribute('data-theme', isDark ? '' : 'dark');
+      });
+    </script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
     "pier": "./bin/pier"
   },
   "scripts": {
-    "build": "npm run build:core && npm run build:full && npm run build:min",
+    "build": "npm run build:css && npm run build:css:min && npm run build:core",
+    "build:css": "sass --no-source-map src/full.scss dist/pier.css",
+    "build:css:min": "sass --no-source-map --style=compressed src/full.scss dist/pier.min.css",
     "build:core": "sass --no-source-map src/pier-core.scss dist/pier-core.css",
-    "build:full": "sass --no-source-map src/full.scss dist/pier.css",
-    "build:min": "sass --no-source-map --style=compressed src/full.scss dist/pier.min.css"
+    "demo": "npm run build:css && node -e \"console.log('Demo ready – open index.html in your browser.')\""
   },
   "devDependencies": {
     "sass": "^1.71.1"

--- a/src/_all.scss
+++ b/src/_all.scss
@@ -1,25 +1,16 @@
-// -----------------------------------------------------------------------------
-// Pier public API
-// -----------------------------------------------------------------------------
-// Re-exports the core modules so `@use "pier"` exposes every mixin,
-// function, and variable. This file does not emit CSS on its own – use
-// `@use "pier/all"` or the generated theme entrypoint to compile the
-// default grid and utilities.
-// -----------------------------------------------------------------------------
-
+@forward "pier/reset";
 @forward "pier/theme.config";
-@forward "pier/config";
+@forward "pier/tokens";
 @forward "pier/functions";
 @forward "pier/mixins";
 @forward "pier/states";
 @forward "pier/layout";
 @forward "pier/layout.patterns";
-@forward "pier/grid";
+@forward "pier/grid" hide breakpoint;
 @forward "pier/utilities";
 @forward "pier/utilities.spacing" show pier-spacing-utilities;
 @forward "pier/utilities.align" show pier-align-utilities;
 @forward "pier/utilities.sizing" show pier-sizing-utilities;
-@forward "pier/tokens";
 @forward "pier/typography";
 @forward "pier/typography.roles";
 @forward "pier/components.tokens";
@@ -30,5 +21,3 @@
 @forward "pier/icons";
 @forward "pier/tooltips";
 @forward "pier/helpers";
-@forward "pier/reset";
-@forward "pier/print";

--- a/src/all.scss
+++ b/src/all.scss
@@ -1,14 +1,7 @@
-@forward "pier/theme.config" show $pier-theme-overrides;
-@use "pier" as pier;
+@use "./_all" as pier;
 
-// -----------------------------------------------------------------------------
-// Complete Pier bundle
-// -----------------------------------------------------------------------------
-// Produces the grid, responsive utilities, reset, print adjustments, and button
-// styles in one shot. Override `$pier-theme-overrides` via `@use` configuration
-// when importing this file to tweak the defaults without re-declaring the entire
-// theme map.
-// -----------------------------------------------------------------------------
-
+// Legacy entry point – mirrors the new `_all` bundle.
+@include pier.pier-apply-theme(pier.$pier-theme);
+@include pier.pier-apply-theme(pier.$pier-theme-dark, "[data-theme='dark']");
 @include pier.generate-grid();
 @include pier.generate-utilities();

--- a/src/full.scss
+++ b/src/full.scss
@@ -1,4 +1,7 @@
-@use "pier-core";
-@use "pier/buttons";
+@use "./_all" as pier;
 
 // Full bundle: core utilities plus component styles.
+@include pier.pier-apply-theme(pier.$pier-theme);
+@include pier.pier-apply-theme(pier.$pier-theme-dark, "[data-theme='dark']");
+@include pier.generate-grid();
+@include pier.generate-utilities();

--- a/src/pier-core.scss
+++ b/src/pier-core.scss
@@ -1,10 +1,7 @@
-@use "pier/theme.config";
-@use "pier/config";
-@use "pier/reset";
-@use "pier/print";
-@use "pier/grid" as grid;
-@use "pier/utilities" as utilities;
+@use "./_all" as pier;
 
 // Core bundle: reset + utilities without component styles.
-@include grid.generate-grid();
-@include utilities.generate-utilities();
+@include pier.pier-apply-theme(pier.$pier-theme);
+@include pier.pier-apply-theme(pier.$pier-theme-dark, "[data-theme='dark']");
+@include pier.generate-grid();
+@include pier.generate-utilities();

--- a/src/pier/_buttons.scss
+++ b/src/pier/_buttons.scss
@@ -1,140 +1,127 @@
+@use "sass:map";
 @use "functions" as fn;
-@use "mixins";
+@use "states";
 
 // -----------------------------------------------------------------------------
 // Button component styles
 // -----------------------------------------------------------------------------
-// Minimal button styling that leverages Pier's colour helpers and spacing
-// tokens. Automatically included by the bundled build but can be imported
-// manually via `@use "pier/buttons"`.
+// Semantic buttons powered by the component token CSS variables. Consumers can
+// override tokens via the theme maps or by redeclaring custom properties in a
+// specific scope.
 // -----------------------------------------------------------------------------
 
-.btn {
+@mixin _btn-base() {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: fn.spacer(2);
-  padding: 0.6rem 1rem;
-  vertical-align: middle;
-  font-weight: bold;
-  font-family: fn.font-family(primary);
-
-  color: fn.color(secondary);
-  border-radius: fn.radius();
+  gap: var(--pier-btn-gap, fn.spacer(2));
+  padding: var(--pier-btn-padding-y, fn.spacer(3)) var(--pier-btn-padding-x, fn.spacer(4));
+  font: inherit;
+  font-weight: var(--pier-btn-font-weight, 600);
+  text-transform: var(--pier-btn-text-transform, none);
+  border-radius: var(--pier-btn-radius, fn.radius());
+  border: var(--pier-btn-border, 1px solid transparent);
+  background: var(--pier-btn-bg, fn.color(primary));
+  color: var(--pier-btn-fg, var(--pier-color-accent-contrast, #fff));
+  box-shadow: var(--pier-btn-shadow, none);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
+    transform 0.15s ease;
   position: relative;
-  transition: background-color 0.4s ease, color 0.1s ease, box-shadow 0.3s ease;
+  text-decoration: none;
+  line-height: 1;
 
-  @include mixins.colour-set(background-color, (border-color, dark));
-  @include mixins.colour-set-state(hover, (background-color, dark), border-color);
-  @include mixins.colour-set-state(active, (background-color, light), border-color);
-  @include mixins.colour-set-state(focus, (background-color, light));
+  @include states.interactive;
+  @include states.focus-ring();
+}
 
-  &:focus-visible {
-    box-shadow: 0 0 0 0.2rem rgba(fn.color(primary), 0.35);
-  }
-
-  &--large {
-    margin: 0;
-    padding: 1rem 1.4rem;
-    font-size: 1.4rem;
-    border-radius: fn.radius(large);
-  }
-
-  &--small {
-    margin: 0;
-    padding: 0.2rem 0.6rem;
-    border-radius: fn.radius(small);
-  }
-
-  &--xsmall {
-    margin: 0;
-    padding: 0.1rem 0.2rem;
-    border-radius: fn.radius(small);
+@mixin _btn-size($name, $scale) {
+  &--#{$name} {
+    font-size: map.get($scale, font-size, 1rem);
+    padding: map.get($scale, padding-y, var(--pier-btn-padding-y)) map.get($scale, padding-x, var(--pier-btn-padding-x));
+    border-radius: map.get($scale, radius, var(--pier-btn-radius));
+    min-height: map.get($scale, min-height, auto);
   }
 }
 
-input.btn,
-input + .btn:last-child {
-  border-bottom-width: 1px;
+.btn {
+  @include _btn-base();
+
+  &:hover,
+  &.is-hovered {
+    background: var(--pier-btn-hover-bg, fn.color(primary, dark));
+  }
+
+  &:active,
+  &.is-active {
+    background: var(--pier-btn-active-bg, fn.color(primary, darker));
+    transform: translateY(1px);
+  }
+
+  &:disabled,
+  &[aria-disabled="true"],
+  &.is-disabled {
+    background: var(--pier-btn-disabled-bg, fn.color(primary, lighter));
+    color: var(--pier-btn-disabled-fg, var(--pier-color-muted));
+    cursor: not-allowed;
+    opacity: 0.8;
+  }
+
+  &.is-loading {
+    color: transparent;
+    pointer-events: none;
+
+    &::after {
+      content: "";
+      width: 1em;
+      height: 1em;
+      border-radius: 50%;
+      border: 2px solid currentColor;
+      border-right-color: transparent;
+      animation: pier-spin 0.75s linear infinite;
+    }
+  }
+
+  &--subtle {
+    background: var(--pier-btn-subtle-bg, transparent);
+    color: var(--pier-btn-subtle-fg, fn.color(primary));
+    border-color: transparent;
+  }
+
+  &--outline {
+    background: transparent;
+    color: var(--pier-btn-fg, fn.color(primary));
+    border: var(--pier-btn-outline-border, 1px solid fn.color(primary));
+  }
+
+  &--ghost {
+    background: var(--pier-btn-ghost-bg, transparent);
+    color: var(--pier-btn-ghost-fg, fn.color(primary));
+    border: 1px solid transparent;
+  }
+
+  @include _btn-size(sm, (
+    font-size: 0.875rem,
+    padding-y: calc(var(--pier-btn-padding-y, fn.spacer(3)) * 0.7),
+    padding-x: calc(var(--pier-btn-padding-x, fn.spacer(4)) * 0.8),
+    radius: calc(var(--pier-btn-radius, fn.radius()) * 0.85),
+  ));
+
+  @include _btn-size(md, (
+    min-height: 2.5rem,
+  ));
+
+  @include _btn-size(lg, (
+    font-size: 1.1rem,
+    padding-y: calc(var(--pier-btn-padding-y, fn.spacer(3)) * 1.2),
+    padding-x: calc(var(--pier-btn-padding-x, fn.spacer(4)) * 1.2),
+    radius: calc(var(--pier-btn-radius, fn.radius()) * 1.1),
+  ));
 }
 
-.group {
-  position: relative;
-  display: block;
-
-  input {
-    transition: border-color 0.2s ease;
-    -webkit-appearance: none;
-    box-shadow: none;
-    border-radius: 0;
-
-    color: fn.color(secondary);
-
-    &.large {
-      padding-left: 0.8rem;
-      padding-right: 0.8rem;
-    }
-
-    &:focus,
-    &:active {
-      border-color: fn.color(secondary);
-    }
-  }
-
-  @include mixins.breakpoint(medium, max) {
-    .btn {
-      display: inline-flex;
-
-      & + .btn {
-        margin-top: -1px;
-      }
-
-      & + .btn:not(:last-child) {
-        border-radius: 0;
-      }
-
-      &:first-child:not(:last-child) {
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-      }
-
-      &:last-child:not(:first-child) {
-        border-top-left-radius: 0;
-        border-top-right-radius: 0;
-      }
-    }
-  }
-
-  @include mixins.breakpoint(medium) {
-    display: inline-flex;
-
-    input {
-      flex: 1;
-    }
-
-    .btn {
-      width: auto;
-
-      & + .btn {
-        margin-top: 0;
-        margin-left: -1px;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-      }
-
-      & + .btn:not(:last-child) {
-        border-radius: 0;
-      }
-
-      &:first-child:not(:last-child) {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-      }
-
-      &:last-child:not(:first-child) {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-      }
-    }
+@keyframes pier-spin {
+  to {
+    transform: rotate(1turn);
   }
 }
+

--- a/src/pier/_components.tokens.scss
+++ b/src/pier/_components.tokens.scss
@@ -1,0 +1,160 @@
+@use "sass:map";
+@use "sass:meta";
+
+// -----------------------------------------------------------------------------
+// Component token helpers
+// -----------------------------------------------------------------------------
+// Converts values from a theme map into CSS custom properties for component
+// layers. These helpers intentionally avoid importing the theme module to keep
+// dependency graphs lean – callers should pass an explicit theme map when
+// querying tokens.
+// -----------------------------------------------------------------------------
+
+@function _theme-value($theme, $key, $fallback: null) {
+  @if map.has-key($theme, $key) {
+    $value: map.get($theme, $key);
+    @if $value != null {
+      @return $value;
+    }
+  }
+
+  @return $fallback;
+}
+
+@function _component-map($theme) {
+  @if map.has-key($theme, components) {
+    @return map.get($theme, components);
+  }
+
+  @return ();
+}
+
+@function pier-component-token($component, $token, $theme) {
+  $components: _component-map($theme);
+
+  @if map.has-key($components, $component) {
+    $config: map.get($components, $component);
+
+    @if map.has-key($config, $token) {
+      @return map.get($config, $token);
+    }
+  }
+
+  @return null;
+}
+
+@function _state-token($theme, $state) {
+  $components: _component-map($theme);
+
+  @if map.has-key($components, states) {
+    $states: map.get($components, states);
+
+    @if map.has-key($states, $state) {
+      @return map.get($states, $state);
+    }
+  }
+
+  @return null;
+}
+
+@mixin _emit-button-vars($theme, $selector) {
+  #{$selector} {
+    --pier-btn-bg: #{pier-component-token(button, bg, $theme)};
+    --pier-btn-fg: #{pier-component-token(button, fg, $theme)};
+    --pier-btn-border: #{pier-component-token(button, border, $theme)};
+    --pier-btn-border-color: #{pier-component-token(button, border-color, $theme)};
+    --pier-btn-gap: #{pier-component-token(button, gap, $theme)};
+    --pier-btn-radius: #{pier-component-token(button, radius, $theme)};
+    --pier-btn-padding-y: #{pier-component-token(button, padding-y, $theme)};
+    --pier-btn-padding-x: #{pier-component-token(button, padding-x, $theme)};
+    --pier-btn-shadow: #{pier-component-token(button, shadow, $theme)};
+    --pier-btn-text-transform: #{pier-component-token(button, text-transform, $theme)};
+    --pier-btn-font-weight: #{pier-component-token(button, font-weight, $theme)};
+    --pier-btn-hover-bg: #{pier-component-token(button, hover-bg, $theme)};
+    --pier-btn-active-bg: #{pier-component-token(button, active-bg, $theme)};
+    --pier-btn-disabled-bg: #{pier-component-token(button, disabled-bg, $theme)};
+    --pier-btn-disabled-fg: #{pier-component-token(button, disabled-fg, $theme)};
+    --pier-btn-subtle-bg: #{pier-component-token(button, subtle-bg, $theme)};
+    --pier-btn-subtle-fg: #{pier-component-token(button, subtle-fg, $theme)};
+    --pier-btn-ghost-bg: #{pier-component-token(button, ghost-bg, $theme)};
+    --pier-btn-ghost-fg: #{pier-component-token(button, ghost-fg, $theme)};
+    --pier-btn-outline-border: #{pier-component-token(button, outline-border, $theme)};
+  }
+}
+
+@mixin _emit-input-vars($theme, $selector) {
+  #{$selector} {
+    --pier-input-bg: #{pier-component-token(input, bg, $theme)};
+    --pier-input-fg: #{pier-component-token(input, fg, $theme)};
+    --pier-input-border: #{pier-component-token(input, border, $theme)};
+    --pier-input-border-active: #{pier-component-token(input, border-active, $theme)};
+    --pier-input-border-muted: #{pier-component-token(input, border-muted, $theme)};
+    --pier-input-radius: #{pier-component-token(input, radius, $theme)};
+    --pier-input-padding-y: #{pier-component-token(input, padding-y, $theme)};
+    --pier-input-padding-x: #{pier-component-token(input, padding-x, $theme)};
+    --pier-input-gap: #{pier-component-token(input, gap, $theme)};
+    --pier-input-placeholder: #{pier-component-token(input, placeholder, $theme)};
+    --pier-input-shadow: #{pier-component-token(input, shadow, $theme)};
+    --pier-input-filled-bg: #{pier-component-token(input, filled-bg, $theme)};
+    --pier-input-disabled-bg: #{pier-component-token(input, disabled-bg, $theme)};
+    --pier-input-disabled-fg: #{pier-component-token(input, disabled-fg, $theme)};
+    --pier-input-focus-ring: #{pier-component-token(input, focus-ring, $theme)};
+    --pier-input-help: #{pier-component-token(input, help-text, $theme)};
+    --pier-input-icon-size: #{pier-component-token(input, icon-size, $theme)};
+  }
+}
+
+@mixin _emit-card-vars($theme, $selector) {
+  #{$selector} {
+    --pier-card-bg: #{pier-component-token(card, bg, $theme)};
+    --pier-card-fg: #{pier-component-token(card, fg, $theme)};
+    --pier-card-border: #{pier-component-token(card, border, $theme)};
+    --pier-card-radius: #{pier-component-token(card, radius, $theme)};
+    --pier-card-shadow: #{pier-component-token(card, shadow, $theme)};
+    --pier-card-padding: #{pier-component-token(card, padding, $theme)};
+  }
+}
+
+@mixin _emit-tooltip-vars($theme, $selector) {
+  #{$selector} {
+    --pier-tooltip-bg: #{pier-component-token(tooltip, bg, $theme)};
+    --pier-tooltip-fg: #{pier-component-token(tooltip, fg, $theme)};
+    --pier-tooltip-radius: #{pier-component-token(tooltip, radius, $theme)};
+    --pier-tooltip-shadow: #{pier-component-token(tooltip, shadow, $theme)};
+    --pier-tooltip-offset: #{pier-component-token(tooltip, offset, $theme)};
+    --pier-tooltip-padding-y: #{pier-component-token(tooltip, padding-y, $theme)};
+    --pier-tooltip-padding-x: #{pier-component-token(tooltip, padding-x, $theme)};
+  }
+}
+
+@mixin _emit-state-vars($theme, $selector) {
+  #{$selector} {
+    --pier-color-success: #{_state-token($theme, success)};
+    --pier-color-warning: #{_state-token($theme, warning)};
+    --pier-color-danger: #{_state-token($theme, danger)};
+  }
+}
+
+@mixin pier-component-css-vars($theme, $selector: ":root") {
+  @include _emit-button-vars($theme, $selector);
+  @include _emit-input-vars($theme, $selector);
+  @include _emit-card-vars($theme, $selector);
+  @include _emit-tooltip-vars($theme, $selector);
+  @include _emit-state-vars($theme, $selector);
+}
+
+@function pier-type-fluid($size, $theme) {
+  $scale: _theme-value($theme, type-scale, ());
+
+  @if map.has-key($scale, $size) {
+    $settings: map.get($scale, $size);
+    $min: _theme-value($settings, min);
+    $max: _theme-value($settings, max);
+
+    @if $min != null and $max != null {
+      @return clamp(var(--pier-type-#{$size}-min), 1vw + #{$min}, var(--pier-type-#{$size}-max));
+    }
+  }
+
+  @return null;
+}

--- a/src/pier/_config.scss
+++ b/src/pier/_config.scss
@@ -1,14 +1,12 @@
 @use "sass:map";
-
 @use "theme.config" as theme;
 
 // -----------------------------------------------------------------------------
 // Pier configuration accessors
 // -----------------------------------------------------------------------------
-// Resolves values from the `$pier-theme` map and exposes them as traditional
-// Sass variables so legacy modules and mixins continue to work. Override
-// `$pier-theme-overrides` via `@use` or call `@include pier-theme(...)` before
-// importing the layout and utility modules for custom themes.
+// Materialises values from the `$pier-theme` map into Sass variables so legacy
+// mixins and functions can rely on a stable interface. Everything resolves back
+// to the theme configuration to keep overrides consistent.
 // -----------------------------------------------------------------------------
 
 $root-font-size: theme.theme-value(root-font-size, 16px) !default;
@@ -17,10 +15,10 @@ $breakpoints: theme.theme-value(
   breakpoints,
   (
     small: 0px,
-    medium: 820px,
-    large: 1220px,
-    huge: 1872px,
-    enormous: 2140px,
+    medium: 48rem,
+    large: 72rem,
+    huge: 96rem,
+    enormous: 120rem,
   )
 ) !default;
 
@@ -28,8 +26,8 @@ $vbreakpoints: theme.theme-value(
   vbreakpoints,
   (
     small: 0px,
-    medium: 800px,
-    large: 1000px,
+    medium: 42rem,
+    large: 62rem,
   )
 ) !default;
 
@@ -37,20 +35,16 @@ $grid: theme.theme-value(
   grid,
   (
     small: (
-      columns: (3, 4, 5, 6, 8),
-      offsets: (2, 3, 6),
+      columns: (2, 3, 4, 6),
+      offsets: (1, 2, 3),
     ),
     medium: (
-      columns: (2, 3, 4, 6, 8, 9, 10, 12),
-      offsets: (1, 2, 3, 4, 5, 6, 8),
+      columns: (2, 3, 4, 6, 8, 10, 12),
+      offsets: (1, 2, 3, 4, 6),
     ),
     large: (
-      columns: (1, 3, 4, 5, 6, 7, 8, 10, 12),
-      offsets: (1, 2, 3, 4, 6, 8, 10),
-    ),
-    huge: (
-      columns: (4, 6, 8, 10, 12),
-      offsets: (2, 4, 6, 8),
+      columns: (2, 3, 4, 6, 8, 12),
+      offsets: (1, 2, 3, 4, 6, 8),
     ),
   )
 ) !default;
@@ -61,12 +55,23 @@ $column-gutter: theme.theme-value(column-gutter, 84px) !default;
 $global-width: theme.theme-value(global-width, map.get($breakpoints, large)) !default;
 $row-width: theme.theme-value(row-width, $global-width) !default;
 
-$color-background: theme.theme-value(color-bg, #f9f9f7) !default;
-$color-accent: theme.theme-value(color-accent, #e86f3e) !default;
-$color-text: theme.theme-value(color-text, #222222) !default;
-
 $space-unit: theme.theme-value(space-unit, 0.5rem) !default;
 $radius-base: theme.theme-value(radius, 0.5rem) !default;
+$radius-lg: theme.theme-value(radius-lg, $radius-base * 1.25) !default;
+$shadow-sm: theme.theme-value(shadow-sm, 0 1px 2px rgba(15, 23, 42, 0.08)) !default;
+$shadow-md: theme.theme-value(shadow-md, 0 12px 20px rgba(15, 23, 42, 0.12)) !default;
+$shadow-lg: theme.theme-value(shadow-lg, 0 28px 45px rgba(15, 23, 42, 0.16)) !default;
+
+$color-background: theme.theme-value(color-bg, #fdfcf7) !default;
+$color-surface: theme.theme-value(color-surface, #ffffff) !default;
+$color-text: theme.theme-value(color-text, #1f1d18) !default;
+$color-muted: theme.theme-value(color-muted, rgba($color-text, 0.65)) !default;
+$color-border: theme.theme-value(color-border, rgba($color-text, 0.18)) !default;
+$color-accent: theme.theme-value(color-accent, #ec6c2f) !default;
+$color-accent-contrast: theme.theme-value(color-accent-contrast, #ffffff) !default;
+$color-success: theme.theme-component(states, success, theme.$pier-theme, #2b8c62) !default;
+$color-warning: theme.theme-component(states, warning, theme.$pier-theme, #b6721c) !default;
+$color-danger: theme.theme-component(states, danger, theme.$pier-theme, #c23f3f) !default;
 
 $spacers: theme.theme-value(
   spacers,
@@ -76,8 +81,10 @@ $spacers: theme.theme-value(
     2: $space-unit * 2,
     3: $space-unit * 3,
     4: $space-unit * 4,
+    5: $space-unit * 5,
     6: $space-unit * 6,
     8: $space-unit * 8,
+    10: $space-unit * 10,
     12: $space-unit * 12,
   )
 ) !default;
@@ -85,10 +92,12 @@ $spacers: theme.theme-value(
 $radii: theme.theme-value(
   radii,
   (
-    xsmall: 0,
-    small: $radius-base * 0.5,
+    sharp: 0,
+    sm: $radius-base * 0.5,
+    md: $radius-base,
     base: $radius-base,
-    large: $radius-base * 1.5,
+    lg: $radius-lg,
+    pill: 999px,
   )
 ) !default;
 
@@ -96,7 +105,9 @@ $borders: theme.theme-value(
   borders,
   (
     0: 0,
+    1: 1px,
     2: 2px,
+    3: 3px,
   )
 ) !default;
 
@@ -120,30 +131,66 @@ $type-ratio: theme.theme-value(
   )
 ) !default;
 
-$heading-weight: theme.theme-value(heading-weight, 900) !default;
+$type-scale: theme.theme-value(
+  type-scale,
+  (
+    xs: (min: 0.75rem, max: 0.8125rem),
+    sm: (min: 0.875rem, max: 0.9375rem),
+    md: (min: 1rem, max: 1.0625rem),
+    lg: (min: 1.25rem, max: 1.375rem),
+    xl: (min: 1.5rem, max: 1.625rem),
+    "2xl": (min: 1.875rem, max: 2.2rem),
+    "3xl": (min: 2.25rem, max: 2.8rem),
+    "4xl": (min: 2.75rem, max: 3.5rem),
+  )
+) !default;
+
+$line-heights: theme.theme-value(
+  line-heights,
+  (
+    tight: 1.1,
+    snug: 1.3,
+    base: 1.5,
+    relaxed: 1.7,
+  )
+) !default;
+
+$heading-weight: theme.theme-value(heading-weight, 800) !default;
 
 $font-stack: theme.theme-value(
   font-stack,
-  ("system-ui", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)
+  ("Inter", "Segoe UI", Roboto, -apple-system, BlinkMacSystemFont, sans-serif)
+) !default;
+
+$font-stack-display: theme.theme-value(
+  font-stack-display,
+  $font-stack
+) !default;
+
+$font-stack-mono: theme.theme-value(
+  font-mono,
+  ("SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace)
 ) !default;
 
 $fonts: theme.theme-value(
   fonts,
   (
     primary: $font-stack,
-    accent: ("Monument", Helvetica, Arial, sans-serif),
-    monospace: ("IBM Plex Mono", monospace, sans-serif),
-    heading: ("Monument", Helvetica, Arial, sans-serif),
+    display: $font-stack-display,
+    monospace: $font-stack-mono,
   )
 ) !default;
 
 $helpers: theme.theme-value(
   helpers,
   (
-    default: $color-accent,
-    primary: $color-text,
-    secondary: #ffffff,
-    surface: $color-background,
+    primary: $color-accent,
+    surface: $color-surface,
+    text: $color-text,
+    muted: $color-muted,
+    success: $color-success,
+    warning: $color-warning,
+    danger: $color-danger,
   )
 ) !default;
 
@@ -181,188 +228,18 @@ $utility-directions: theme.theme-value(
 $container-widths: theme.theme-value(
   container-widths,
   (
-    full: 100%,
-    default: map.get($breakpoints, large),
-    narrow: 48rem,
-    readable: 72ch,
+    narrow: 40rem,
+    default: 72rem,
+    wide: 92rem,
+    full: min(100%, 120rem),
   )
 ) !default;
 
-$stack-default-gap: theme.theme-value(stack-default-gap, map.get($spacers, 6)) !default;
-$cluster-default-gap: theme.theme-value(cluster-default-gap, map.get($spacers, 6)) !default;
+$stack-default-gap: theme.theme-value(stack-default-gap, map.get($spacers, 4)) !default;
+$cluster-default-gap: theme.theme-value(cluster-default-gap, map.get($spacers, 4)) !default;
 $cluster-align: theme.theme-value(cluster-align, center) !default;
 
-$fluid-min-vw: theme.theme-value(fluid-min-vw, map.get($breakpoints, small)) !default;
-$fluid-max-vw: theme.theme-value(fluid-max-vw, map.get($breakpoints, large)) !default;
+$fluid-min-vw: theme.theme-value(fluid-min-vw, 20rem) !default;
+$fluid-max-vw: theme.theme-value(fluid-max-vw, 96rem) !default;
 
-@mixin _apply-config() {
-  $root-font-size: theme.theme-value(root-font-size, 16px) !global;
-  $breakpoints: theme.theme-value(
-    breakpoints,
-    (
-      small: 0px,
-      medium: 820px,
-      large: 1220px,
-      huge: 1872px,
-      enormous: 2140px,
-    )
-  ) !global;
-  $vbreakpoints: theme.theme-value(
-    vbreakpoints,
-    (
-      small: 0px,
-      medium: 800px,
-      large: 1000px,
-    )
-  ) !global;
-  $grid: theme.theme-value(
-    grid,
-    (
-      small: (
-        columns: (3, 4, 5, 6, 8),
-        offsets: (2, 3, 6),
-      ),
-      medium: (
-        columns: (2, 3, 4, 6, 8, 9, 10, 12),
-        offsets: (1, 2, 3, 4, 5, 6, 8),
-      ),
-      large: (
-        columns: (1, 3, 4, 5, 6, 7, 8, 10, 12),
-        offsets: (1, 2, 3, 4, 6, 8, 10),
-      ),
-      huge: (
-        columns: (4, 6, 8, 10, 12),
-        offsets: (2, 4, 6, 8),
-      ),
-    )
-  ) !global;
-  $column-count: theme.theme-value(column-count, 12) !global;
-  $column-gutter: theme.theme-value(column-gutter, 84px) !global;
-  $global-width: theme.theme-value(global-width, map.get($breakpoints, large)) !global;
-  $row-width: theme.theme-value(row-width, $global-width) !global;
-  $color-background: theme.theme-value(color-bg, #f9f9f7) !global;
-  $color-accent: theme.theme-value(color-accent, #e86f3e) !global;
-  $color-text: theme.theme-value(color-text, #222222) !global;
-  $space-unit: theme.theme-value(space-unit, 0.5rem) !global;
-  $radius-base: theme.theme-value(radius, 0.5rem) !global;
-  $spacers: theme.theme-value(
-    spacers,
-    (
-      0: 0rem,
-      1: $space-unit,
-      2: $space-unit * 2,
-      3: $space-unit * 3,
-      4: $space-unit * 4,
-      6: $space-unit * 6,
-      8: $space-unit * 8,
-      12: $space-unit * 12,
-    )
-  ) !global;
-  $radii: theme.theme-value(
-    radii,
-    (
-      xsmall: 0,
-      small: $radius-base * 0.5,
-      base: $radius-base,
-      large: $radius-base * 1.5,
-    )
-  ) !global;
-  $borders: theme.theme-value(
-    borders,
-    (
-      0: 0,
-      2: 2px,
-    )
-  ) !global;
-  $type-base: theme.theme-value(
-    type-base,
-    (
-      small: 3.8vw,
-      medium: 2vw,
-      large: 1.4vw,
-      huge: 1.3vw,
-    )
-  ) !global;
-  $type-ratio: theme.theme-value(
-    type-ratio,
-    (
-      small: 1.26,
-      medium: 1.5,
-      large: 1.6,
-      huge: 1.575,
-    )
-  ) !global;
-  $heading-weight: theme.theme-value(heading-weight, 900) !global;
-  $font-stack: theme.theme-value(
-    font-stack,
-    ("system-ui", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif)
-  ) !global;
-  $fonts: theme.theme-value(
-    fonts,
-    (
-      primary: $font-stack,
-      accent: ("Monument", Helvetica, Arial, sans-serif),
-      monospace: ("IBM Plex Mono", monospace, sans-serif),
-      heading: ("Monument", Helvetica, Arial, sans-serif),
-    )
-  ) !global;
-  $helpers: theme.theme-value(
-    helpers,
-    (
-      default: $color-accent,
-      primary: $color-text,
-      secondary: #ffffff,
-      surface: $color-background,
-    )
-  ) !global;
-  $color-steps: theme.theme-value(
-    color-steps,
-    (
-      lighter: (
-        lightness: 20%,
-        saturation: -6%,
-      ),
-      light: (
-        lightness: 10%,
-        saturation: -4%,
-      ),
-      dark: (
-        lightness: -12%,
-        saturation: -4%,
-      ),
-      darker: (
-        lightness: -24%,
-        saturation: -6%,
-      ),
-      contrast: (
-        lightness: 50%,
-        saturation: -12%,
-      ),
-    )
-  ) !global;
-  $utility-directions: theme.theme-value(
-    utility-directions,
-    (x, y, block, inline, top, right, bottom, left)
-  ) !global;
-  $container-widths: theme.theme-value(
-    container-widths,
-    (
-      full: 100%,
-      default: map.get($breakpoints, large),
-      narrow: 48rem,
-      readable: 72ch,
-    )
-  ) !global;
-  $stack-default-gap: theme.theme-value(stack-default-gap, map.get($spacers, 6)) !global;
-  $cluster-default-gap: theme.theme-value(cluster-default-gap, map.get($spacers, 6)) !global;
-  $cluster-align: theme.theme-value(cluster-align, center) !global;
-  $fluid-min-vw: theme.theme-value(fluid-min-vw, map.get($breakpoints, small)) !global;
-  $fluid-max-vw: theme.theme-value(fluid-max-vw, map.get($breakpoints, large)) !global;
-}
-
-@include _apply-config();
-
-@mixin pier-theme($config) {
-  theme.$pier-theme: map.deep-merge(theme.$pier-theme, $config) !global;
-  @include _apply-config();
-}
+$components: theme.theme-value(components, ()) !default;

--- a/src/pier/_forms.base.scss
+++ b/src/pier/_forms.base.scss
@@ -1,0 +1,275 @@
+@use "sass:map";
+@use "functions" as fn;
+@use "states";
+
+// -----------------------------------------------------------------------------
+// Form controls – base styles
+// -----------------------------------------------------------------------------
+// Provides the foundational styling for text inputs, selects, checkboxes, and
+// other interactive controls. Variants derive from CSS custom properties exposed
+// by the component token layer.
+// -----------------------------------------------------------------------------
+
+$input-sizes: (
+  sm: (
+    font-size: 0.875rem,
+    padding-y: calc(var(--pier-input-padding-y, #{fn.spacer(2)}) * 0.7),
+    padding-x: calc(var(--pier-input-padding-x, #{fn.spacer(3)}) * 0.85),
+    height: 2.25rem,
+  ),
+  md: (
+    font-size: 1rem,
+    padding-y: var(--pier-input-padding-y, #{fn.spacer(3)}),
+    padding-x: var(--pier-input-padding-x, #{fn.spacer(4)}),
+    height: 2.75rem,
+  ),
+  lg: (
+    font-size: 1.125rem,
+    padding-y: calc(var(--pier-input-padding-y, #{fn.spacer(3)}) * 1.2),
+    padding-x: calc(var(--pier-input-padding-x, #{fn.spacer(4)}) * 1.2),
+    height: 3.25rem,
+  ),
+) !default;
+
+@mixin pier-input(
+  $size: md,
+  $variant: outline,
+  $icon-left: false,
+  $icon-right: false
+) {
+  $config: map.get($input-sizes, $size);
+
+  font-size: map.get($config, font-size);
+  min-height: map.get($config, height);
+  padding: map.get($config, padding-y) map.get($config, padding-x);
+  padding-left: calc(#{map.get($config, padding-x)} + var(--pier-input-icon-offset-left, 0px));
+  padding-right: calc(#{map.get($config, padding-x)} + var(--pier-input-icon-offset-right, 0px));
+  @if $icon-left {
+    --pier-input-icon-offset-left: calc(var(--pier-input-icon-size, 1.125rem) + var(--pier-input-gap, #{fn.spacer(2)}));
+  }
+  @if $icon-right {
+    --pier-input-icon-offset-right: calc(var(--pier-input-icon-size, 1.125rem) + var(--pier-input-gap, #{fn.spacer(2)}));
+  }
+  background-color: if($variant == filled, var(--pier-input-filled-bg, rgba(0, 0, 0, 0.02)), var(--pier-input-bg, #fff));
+  border: if($variant == filled, var(--pier-input-border-muted, 1px solid rgba(0, 0, 0, 0.1)), var(--pier-input-border, 1px solid rgba(0, 0, 0, 0.12)));
+  border-radius: var(--pier-input-radius, #{fn.radius()});
+  box-shadow: var(--pier-input-shadow, none);
+  color: var(--pier-input-fg, inherit);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+
+  @include states.focus-ring(var(--pier-input-focus-ring, var(--pier-focus-ring-color)));
+
+  &:focus,
+  &:focus-visible {
+    border: var(--pier-input-border-active, 1px solid var(--pier-color-accent));
+  }
+
+  &::placeholder {
+    color: var(--pier-input-placeholder, rgba(0, 0, 0, 0.6));
+  }
+
+  &:disabled,
+  &[aria-disabled="true"],
+  &.is-disabled {
+    background: var(--pier-input-disabled-bg, rgba(0, 0, 0, 0.04));
+    color: var(--pier-input-disabled-fg, rgba(0, 0, 0, 0.45));
+    cursor: not-allowed;
+  }
+
+  &.is-readonly,
+  &:read-only {
+    background: var(--pier-input-bg);
+    border: var(--pier-input-border-muted, 1px solid rgba(0, 0, 0, 0.08));
+    color: inherit;
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pier-input-gap, #{fn.spacer(2)});
+  width: 100%;
+}
+
+.label {
+  font-weight: 600;
+  color: var(--pier-color-text, inherit);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pier-input-gap, #{fn.spacer(2)});
+}
+
+.help {
+  font-size: 0.875rem;
+  color: var(--pier-input-help, var(--pier-color-muted));
+}
+
+.input,
+.textarea,
+.select {
+  display: block;
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  background-color: transparent;
+  appearance: none;
+
+  @include pier-input();
+}
+
+.input {
+  &--sm { @include pier-input(sm); }
+  &--lg { @include pier-input(lg); }
+  &--filled { @include pier-input(md, filled); }
+  &--icon-left { --pier-input-icon-offset-left: calc(var(--pier-input-icon-size, 1.125rem) + var(--pier-input-gap, #{fn.spacer(2)})); }
+  &--icon-right { --pier-input-icon-offset-right: calc(var(--pier-input-icon-size, 1.125rem) + var(--pier-input-gap, #{fn.spacer(2)})); }
+}
+
+.textarea {
+  min-height: 8rem;
+  resize: vertical;
+  line-height: var(--pier-line-relaxed, 1.6);
+}
+
+.select {
+  position: relative;
+  padding-right: calc(var(--pier-input-padding-x, #{fn.spacer(4)}) * 1.6);
+  background-image:
+    linear-gradient(45deg, transparent 50%, currentColor 50%),
+    linear-gradient(135deg, currentColor 50%, transparent 50%);
+  background-position:
+    calc(100% - var(--pier-input-padding-x, #{fn.spacer(4)}) * 0.8) calc(50% - 0.25em),
+    calc(100% - var(--pier-input-padding-x, #{fn.spacer(4)}) * 0.4) calc(50% - 0.25em);
+  background-size: 0.5em 0.5em;
+  background-repeat: no-repeat;
+}
+
+.checkbox,
+.radio,
+.switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pier-input-gap, #{fn.spacer(2)});
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.checkbox input,
+.radio input,
+.switch input {
+  appearance: none;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: var(--pier-input-border, 1px solid rgba(0, 0, 0, 0.12));
+  border-radius: calc(var(--pier-input-radius, #{fn.radius()}) * 0.75);
+  background-color: var(--pier-input-bg);
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+
+  @include states.focus-ring(var(--pier-input-focus-ring));
+}
+
+.checkbox input:checked {
+  background: var(--pier-color-accent);
+  border-color: var(--pier-color-accent);
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0.25rem;
+    border: solid var(--pier-color-accent-contrast);
+    border-width: 0 0.125rem 0.125rem 0;
+    transform: rotate(45deg);
+  }
+}
+
+.radio input {
+  border-radius: 999px;
+}
+
+.radio input:checked {
+  border-color: var(--pier-color-accent);
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: 0.3rem;
+    border-radius: 999px;
+    background: var(--pier-color-accent);
+  }
+}
+
+.switch input {
+  width: 2.75rem;
+  border-radius: 999px;
+  background: var(--pier-input-disabled-bg, rgba(0, 0, 0, 0.05));
+}
+
+.switch input::after {
+  content: "";
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 50%;
+  background: var(--pier-input-bg, #fff);
+  transition: transform 0.2s ease;
+}
+
+.switch input:checked {
+  background: var(--pier-color-accent);
+  border-color: var(--pier-color-accent);
+}
+
+.switch input:checked::after {
+  transform: translateX(1.4rem);
+  background: var(--pier-color-accent-contrast);
+}
+
+.range {
+  width: 100%;
+  appearance: none;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: var(--pier-input-disabled-bg, rgba(0, 0, 0, 0.12));
+}
+
+.range::-webkit-slider-thumb {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--pier-color-accent);
+  border: 0;
+  cursor: pointer;
+}
+
+.range::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--pier-color-accent);
+  border: 0;
+  cursor: pointer;
+}
+
+.file {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pier-input-gap, #{fn.spacer(2)});
+  padding: var(--pier-input-padding-y) var(--pier-input-padding-x);
+  border: var(--pier-input-border);
+  border-radius: var(--pier-input-radius);
+  background: var(--pier-input-bg);
+}
+
+.file input[type="file"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}

--- a/src/pier/_forms.feedback.scss
+++ b/src/pier/_forms.feedback.scss
@@ -1,0 +1,76 @@
+// -----------------------------------------------------------------------------
+// Form validation feedback
+// -----------------------------------------------------------------------------
+
+@mixin _state($color) {
+  border-color: #{$color};
+  box-shadow: 0 0 0 1px #{$color};
+
+  & ~ .help,
+  & ~ .field__message,
+  .help,
+  .field__message {
+    color: #{$color};
+  }
+}
+
+.field {
+  &__message {
+    font-size: 0.875rem;
+    color: var(--pier-input-help, var(--pier-color-muted));
+  }
+
+  &.is-valid {
+    color: var(--pier-color-success);
+  }
+
+  &.is-warning {
+    color: var(--pier-color-warning);
+  }
+
+  &.is-invalid {
+    color: var(--pier-color-danger);
+  }
+}
+
+.input,
+.textarea,
+.select,
+.checkbox input,
+.radio input,
+.switch input,
+.range {
+  &.is-valid,
+  &:is(.is-valid) {
+    @include _state(var(--pier-color-success));
+  }
+
+  &.is-warning,
+  &:is(.is-warning) {
+    @include _state(var(--pier-color-warning));
+  }
+
+  &.is-invalid,
+  &:is(.is-invalid) {
+    @include _state(var(--pier-color-danger));
+  }
+}
+
+.field.is-valid .input,
+.field.is-valid .textarea,
+.field.is-valid .select { @include _state(var(--pier-color-success)); }
+
+.field.is-warning .input,
+.field.is-warning .textarea,
+.field.is-warning .select { @include _state(var(--pier-color-warning)); }
+
+.field.is-invalid .input,
+.field.is-invalid .textarea,
+.field.is-invalid .select { @include _state(var(--pier-color-danger)); }
+
+.field[data-variant="filled"] .input,
+.field[data-variant="filled"] .textarea,
+.field[data-variant="filled"] .select {
+  background: var(--pier-input-filled-bg);
+  border: var(--pier-input-border-muted);
+}

--- a/src/pier/_forms.inline.scss
+++ b/src/pier/_forms.inline.scss
@@ -1,0 +1,138 @@
+@use "sass:map";
+@use "functions" as fn;
+@use "states";
+@use "forms.base" as base;
+
+// -----------------------------------------------------------------------------
+// Form inline patterns
+// -----------------------------------------------------------------------------
+
+$group-sizes: (
+  sm: (
+    size: sm,
+    gap: fn.spacer(2),
+  ),
+  md: (
+    size: md,
+    gap: fn.spacer(2),
+  ),
+  lg: (
+    size: lg,
+    gap: fn.spacer(3),
+  ),
+) !default;
+
+@mixin _group-size($name) {
+  $settings: map.get($group-sizes, $name);
+  $size: if($settings != null and map.has-key($settings, size), map.get($settings, size), md);
+
+  .input {
+    @include base.pier-input($size);
+    border: 0;
+    border-radius: 0;
+  }
+
+  .btn {
+    @extend .btn--#{$size} !optional;
+  }
+}
+
+.input-group {
+  display: inline-flex;
+  align-items: stretch;
+  width: 100%;
+  border: var(--pier-input-border, 1px solid rgba(0, 0, 0, 0.12));
+  border-radius: var(--pier-input-radius, #{fn.radius()});
+  overflow: hidden;
+  background: var(--pier-input-bg, #fff);
+  position: relative;
+  isolation: isolate;
+
+  &:focus-within {
+    border: var(--pier-input-border-active, 1px solid var(--pier-color-accent));
+    box-shadow: 0 0 0 1px var(--pier-input-focus-ring, var(--pier-color-accent)) inset;
+  }
+
+  @include _group-size(md);
+
+  &--sm { @include _group-size(sm); }
+  &--lg { @include _group-size(lg); }
+}
+
+.input-group__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 fn.spacer(2);
+  color: var(--pier-color-muted);
+  pointer-events: none;
+
+  &--interactive {
+    pointer-events: auto;
+    cursor: pointer;
+
+    @include states.focus-ring();
+  }
+}
+
+.input-group__addon {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 fn.spacer(3);
+  background: var(--pier-input-disabled-bg, rgba(0, 0, 0, 0.06));
+  color: var(--pier-input-fg);
+  border-left: 1px solid transparent;
+}
+
+.input-group__btn {
+  border-radius: 0;
+}
+
+.input-group > * {
+  flex: 0 0 auto;
+}
+
+.input-group > .input {
+  flex: 1 1 auto;
+  border: 0;
+  background: transparent;
+  min-width: 0;
+}
+
+.input-group__icon--left + .input,
+.input-group__addon--left + .input {
+  --pier-input-icon-offset-left: calc(var(--pier-input-icon-size, 1.125rem) + var(--pier-input-gap, #{fn.spacer(2)}));
+}
+
+.input + .input-group__icon--right,
+.input + .input-group__addon--right {
+  --pier-input-icon-offset-right: calc(var(--pier-input-icon-size, 1.125rem) + var(--pier-input-gap, #{fn.spacer(2)}));
+}
+
+.input--with-btn {
+  border-right: 1px solid transparent;
+}
+
+.input--clearable {
+  position: relative;
+
+  .input__clear {
+    position: absolute;
+    top: 50%;
+    right: calc(var(--pier-input-padding-x, #{fn.spacer(4)}) * 0.75);
+    transform: translateY(-50%);
+    background: transparent;
+    border: 0;
+    color: var(--pier-color-muted);
+    cursor: pointer;
+
+    @include states.focus-ring();
+  }
+}
+
+.inline-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pier-input-gap, #{fn.spacer(2)});
+  align-items: center;
+}

--- a/src/pier/_icons.scss
+++ b/src/pier/_icons.scss
@@ -1,0 +1,49 @@
+@use "sass:map";
+@use "functions" as fn;
+
+// -----------------------------------------------------------------------------
+// Icon helpers
+// -----------------------------------------------------------------------------
+
+$icon-sizes: (
+  sm: 1rem,
+  md: 1.25rem,
+  lg: 1.5rem,
+) !default;
+
+.icon {
+  --pier-icon-size: map.get($icon-sizes, md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--pier-icon-size);
+  height: var(--pier-icon-size);
+  line-height: 1;
+  flex-shrink: 0;
+  color: currentColor;
+  vertical-align: middle;
+
+  svg,
+  img {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  &--sm { --pier-icon-size: map.get($icon-sizes, sm); }
+  &--lg { --pier-icon-size: map.get($icon-sizes, lg); }
+}
+
+@mixin pier-icon($placement: left, $gap: var(--pier-input-gap, #{fn.spacer(2)})) {
+  display: inline-flex;
+  align-items: center;
+  gap: $gap;
+
+  @if $placement == right {
+    flex-direction: row-reverse;
+  }
+
+  .icon {
+    margin-#{$placement}: 0;
+  }
+}

--- a/src/pier/_layout.patterns.scss
+++ b/src/pier/_layout.patterns.scss
@@ -1,0 +1,44 @@
+@use "config";
+@use "layout";
+@use "mixins" as mix;
+
+// -----------------------------------------------------------------------------
+// Layout patterns
+// -----------------------------------------------------------------------------
+
+.stack {
+  --stack-gap: var(--stack-gap, var(--pier-stack-gap, #{config.$stack-default-gap}));
+  @include layout.stack(var(--stack-gap));
+}
+
+.cluster {
+  --cluster-gap: var(--cluster-gap, var(--pier-cluster-gap, #{config.$cluster-default-gap}));
+  --cluster-align: var(--cluster-align, var(--pier-cluster-align, #{config.$cluster-align}));
+  @include layout.cluster(var(--cluster-gap), var(--cluster-align));
+}
+
+.container {
+  --container-gutter: var(--container-gutter, calc(var(--pier-space-unit, #{config.$space-unit}) * 4));
+  @include layout.container();
+
+  &--wide { @include layout.container(wide); }
+  &--narrow { @include layout.container(narrow); }
+}
+
+.sidebar {
+  --sidebar-side: var(--sidebar-side, 30%);
+  --sidebar-gap: var(--sidebar-gap, var(--pier-stack-gap, #{config.$stack-default-gap}));
+  @include layout.sidebar(var(--sidebar-side), var(--sidebar-gap));
+}
+
+.nav {
+  --nav-gap: var(--nav-gap, var(--pier-cluster-gap, #{config.$cluster-default-gap}));
+  @include layout.nav(var(--nav-gap));
+}
+
+.cover {
+  --cover-min: var(--cover-min, 60vh);
+  --cover-align: var(--cover-align, center);
+  --cover-justify: var(--cover-justify, center);
+  @include layout.cover(var(--cover-min), var(--cover-align), var(--cover-justify));
+}

--- a/src/pier/_layout.scss
+++ b/src/pier/_layout.scss
@@ -4,13 +4,13 @@
 
 @use "config" as config;
 @use "functions" as fn;
+@use "mixins" as mix;
 
 // -----------------------------------------------------------------------------
 // Layout primitives
 // -----------------------------------------------------------------------------
-// A suite of composable layout mixins (stack, cluster, auto-grid, container)
-// that make it easy to build responsive flows. These are exposed as part of the
-// main Pier namespace and reused inside the utility generator.
+// Mixins that power the class-backed layout patterns. These can be composed
+// directly or consumed via `@use "pier/layout"`.
 // -----------------------------------------------------------------------------
 
 @function _container-width($size) {
@@ -28,13 +28,16 @@
   @return $size;
 }
 
-@mixin container($size: default, $align: center, $padding: fn.rem-calc(math.div(config.$column-gutter, 2))) {
-  width: 100%;
-  max-width: _container-width($size);
+@mixin container(
+  $size: default,
+  $align: center,
+  $padding: fn.rem-calc(math.div(config.$column-gutter, 2))
+) {
+  width: min(100%, _container-width($size));
   margin-left: if($align == left, 0, auto);
   margin-right: if($align == right, 0, auto);
-  padding-left: $padding;
-  padding-right: $padding;
+  padding-left: var(--container-gutter, #{$padding});
+  padding-right: var(--container-gutter, #{$padding});
 }
 
 @mixin stack($gap: config.$stack-default-gap, $selector: '> * + *') {
@@ -59,6 +62,53 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax($min, 1fr));
   gap: $gap;
+}
+
+@mixin sidebar(
+  $side: 30%,
+  $gap: config.$stack-default-gap,
+  $collapse: medium
+) {
+  display: flex;
+  gap: $gap;
+  align-items: flex-start;
+
+  > :first-child {
+    flex: 0 0 $side;
+    min-width: min(100%, $side);
+  }
+
+  > :last-child {
+    flex: 1 1 0%;
+    min-width: min(100%, calc(100% - #{$side}));
+  }
+
+  @include mix.breakpoint($collapse, max) {
+    flex-direction: column;
+
+    > * {
+      flex: 1 1 auto;
+      min-width: 100%;
+    }
+  }
+}
+
+@mixin nav($gap: config.$cluster-default-gap) {
+  @include cluster($gap, space-between);
+  align-items: center;
+}
+
+@mixin cover(
+  $min-height: 60vh,
+  $align: center,
+  $justify: center
+) {
+  display: flex;
+  flex-direction: column;
+  min-height: $min-height;
+  align-items: $align;
+  justify-content: $justify;
+  padding: config.$stack-default-gap;
 }
 
 @mixin bleed($amount) {

--- a/src/pier/_mixins.scss
+++ b/src/pier/_mixins.scss
@@ -22,10 +22,30 @@
 
     @if $direction == max {
       $next: if($breakpoint == small, map.get($map, medium), $value);
-      $value: $next - 1px;
+      @if meta.type-of($next) == "number" {
+        @if math.is-unitless($next) {
+          $value: fn.rem-calc($next) - fn.rem-calc(1px);
+        } @else if math.compatible($next, 1px) {
+          $value: $next - 1px;
+        } @else if math.compatible($next, 1rem) {
+          $value: $next - fn.rem-calc(1px);
+        } @else {
+          $value: $next;
+        }
+      } @else {
+        $value: $next;
+      }
     }
 
-    @media screen and (#{$direction}-#{$orientation}: fn.rem-calc($value)) {
+    $query-value: $value;
+
+    @if meta.type-of($value) == "number" {
+      @if math.is-unitless($value) or math.compatible($value, 1px) {
+        $query-value: fn.rem-calc($value);
+      }
+    }
+
+    @media screen and (#{$direction}-#{$orientation}: #{$query-value}) {
       @content;
     }
   } @else {

--- a/src/pier/_states.scss
+++ b/src/pier/_states.scss
@@ -1,0 +1,57 @@
+@use "sass:meta";
+
+// -----------------------------------------------------------------------------
+// State patterns and helpers
+// -----------------------------------------------------------------------------
+// Shared interaction styles used across buttons, inputs, and inline controls.
+// -----------------------------------------------------------------------------
+
+@mixin focus-ring($color: var(--pier-focus-ring-color), $offset: 2px, $width: 2px) {
+  outline: none;
+
+  &:focus-visible {
+    box-shadow: 0 0 0 $offset #{$color};
+  }
+}
+
+@mixin interactive {
+  cursor: pointer;
+  text-decoration: none;
+
+  &:disabled,
+  &[aria-disabled="true"],
+  &.is-disabled {
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+}
+
+@mixin transition($properties...) {
+  $list: if(meta.type-of($properties) == "list", $properties, ($properties,));
+
+  transition: $list;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
+.is-hovered {
+  &,
+  &:hover {
+    filter: brightness(0.96);
+  }
+}
+
+.is-active {
+  &,
+  &:active {
+    filter: brightness(0.9);
+  }
+}
+
+.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  pointer-events: none;
+}

--- a/src/pier/_theme.config.scss
+++ b/src/pier/_theme.config.scss
@@ -1,59 +1,158 @@
+@use "sass:color";
 @use "sass:map";
+@use "sass:meta";
+
+@use "components.tokens" as component_tokens;
 
 // -----------------------------------------------------------------------------
 // Pier theme configuration
 // -----------------------------------------------------------------------------
-// Defines the global `$pier-theme` map and provides helpers for merging
-// overrides. Consumers can either override `$pier-theme-overrides` via `@use`
-// configuration or call `@include pier-theme(...)` to apply changes at runtime.
+// Declares the default light and dark theme maps used across the framework and
+// exposes helpers for reading individual keys. Themes are expressed entirely via
+// maps so they can be merged or overridden through `@use` configuration. The
+// `pier-apply-theme()` mixin emits CSS custom properties for both the base token
+// set and the component specific layers, enabling runtime theme switching by
+// toggling a `data-theme` attribute.
 // -----------------------------------------------------------------------------
 
+$pier-theme-overrides: () !default;
+$pier-theme-dark-overrides: () !default;
+
+@function _fallback($map, $key, $default: null) {
+  @if map.has-key($map, $key) {
+    $value: map.get($map, $key);
+    @if $value != null {
+      @return $value;
+    }
+  }
+
+  @return $default;
+}
+
+@function _build-component-defaults($theme) {
+  $space: _fallback($theme, space-unit, 0.5rem);
+  $radius: _fallback($theme, radius, 0.5rem);
+  $radius-lg: _fallback($theme, radius-lg, $radius * 1.25);
+  $surface: _fallback($theme, color-surface, _fallback($theme, color-bg, #ffffff));
+  $text: _fallback($theme, color-text, #1f1d18);
+  $muted: _fallback($theme, color-muted, rgba($text, 0.7));
+  $border: _fallback($theme, color-border, rgba($text, 0.12));
+  $accent: _fallback($theme, color-accent, #ec6c2f);
+  $accent-contrast: _fallback($theme, color-accent-contrast, #ffffff);
+  $shadow-sm: _fallback($theme, shadow-sm, 0 1px 2px rgba(15, 23, 42, 0.08));
+  $shadow-md: _fallback($theme, shadow-md, 0 12px 20px rgba(15, 23, 42, 0.12));
+  $shadow-lg: _fallback($theme, shadow-lg, 0 28px 45px rgba(15, 23, 42, 0.16));
+  $success: _fallback($theme, color-success, #22795e);
+  $warning: _fallback($theme, color-warning, #b6721c);
+  $danger: _fallback($theme, color-danger, #c23f3f);
+
+  $defaults: (
+    button: (
+      bg: $accent,
+      fg: $accent-contrast,
+      border: 1px solid transparent,
+      hover-bg: color.mix($accent, #000, $weight: 10%),
+      active-bg: color.mix($accent, #000, $weight: 16%),
+      disabled-bg: color.mix($accent, $surface, $weight: 45%),
+      disabled-fg: color.mix($accent-contrast, $surface, $weight: 45%),
+      radius: $radius,
+      gap: $space,
+      padding-y: $space * 1.25,
+      padding-x: $space * 2,
+      shadow: $shadow-sm,
+      text-transform: none,
+      font-weight: 600,
+      outline-border: 1px solid $accent,
+      subtle-bg: color.mix($accent, $surface, $weight: 14%),
+      subtle-fg: $accent,
+      ghost-fg: $accent,
+      ghost-bg: transparent,
+      border-color: $accent,
+    ),
+    input: (
+      bg: $surface,
+      fg: $text,
+      border: 1px solid $border,
+      border-active: 1px solid $accent,
+      border-muted: 1px solid rgba($border, 0.65),
+      radius: $radius,
+      padding-y: $space * 1.1,
+      padding-x: $space * 1.5,
+      gap: $space,
+      placeholder: rgba($text, 0.55),
+      shadow: $shadow-sm,
+      filled-bg: color.mix($surface, $accent, $weight: 8%),
+      disabled-bg: color.mix($surface, #000, $weight: 8%),
+      disabled-fg: color.mix($text, $surface, $weight: 60%),
+      focus-ring: $accent,
+      help-text: $muted,
+      icon-size: 1.125rem,
+    ),
+    card: (
+      bg: $surface,
+      fg: $text,
+      border: 1px solid rgba($border, 0.8),
+      radius: $radius-lg,
+      shadow: $shadow-md,
+      padding: $space * 4,
+    ),
+    tooltip: (
+      bg: color.mix($text, #000, $weight: 80%),
+      fg: $accent-contrast,
+      radius: $radius,
+      shadow: $shadow-lg,
+      offset: 0.5rem,
+      padding-y: $space * 1.25,
+      padding-x: $space * 1.5,
+    ),
+    states: (
+      success: $success,
+      warning: $warning,
+      danger: $danger,
+    ),
+  );
+
+  @if map.has-key($theme, components) {
+    @return map.deep-merge($defaults, map.get($theme, components));
+  }
+
+  @return $defaults;
+}
+
 $pier-theme-defaults: (
-  color-bg: #f9f9f7,
-  color-accent: #e86f3e,
-  color-text: #222222,
+  color-bg: #fdfcf7,
+  color-surface: #ffffff,
+  color-text: #1f1d18,
+  color-muted: #6f6b62,
+  color-border: #dcd5c9,
+  color-accent: #ec6c2f,
+  color-accent-contrast: #ffffff,
+  color-success: #2b8c62,
+  color-warning: #b6721c,
+  color-danger: #c23f3f,
   radius: 0.5rem,
+  radius-lg: 0.75rem,
+  shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08),
+  shadow-md: 0 12px 20px rgba(15, 23, 42, 0.12),
+  shadow-lg: 0 28px 45px rgba(15, 23, 42, 0.16),
   space-unit: 0.5rem,
-  font-stack: ("system-ui", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif),
-  breakpoints: (
-    small: 0px,
-    medium: 820px,
-    large: 1220px,
-    huge: 1872px,
-    enormous: 2140px,
+  font-stack: ("Inter", "Segoe UI", Roboto, -apple-system, BlinkMacSystemFont, sans-serif),
+  font-mono: ("SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace),
+  line-heights: (
+    tight: 1.1,
+    snug: 1.3,
+    base: 1.5,
+    relaxed: 1.7,
   ),
-  vbreakpoints: (
-    small: 0px,
-    medium: 800px,
-    large: 1000px,
-  ),
-  grid: (
-    small: (
-      columns: (3, 4, 5, 6, 8),
-      offsets: (2, 3, 6),
-    ),
-    medium: (
-      columns: (2, 3, 4, 6, 8, 9, 10, 12),
-      offsets: (1, 2, 3, 4, 5, 6, 8),
-    ),
-    large: (
-      columns: (1, 3, 4, 5, 6, 7, 8, 10, 12),
-      offsets: (1, 2, 3, 4, 6, 8, 10),
-    ),
-    huge: (
-      columns: (4, 6, 8, 10, 12),
-      offsets: (2, 4, 6, 8),
-    ),
-  ),
-  column-count: 12,
-  column-gutter: 84px,
-  global-width: null,
-  row-width: null,
-  radii: null,
-  spacers: null,
-  borders: (
-    0: 0,
-    2: 2px,
+  type-scale: (
+    xs: (min: 0.75rem, max: 0.8125rem),
+    sm: (min: 0.875rem, max: 0.9375rem),
+    md: (min: 1rem, max: 1.0625rem),
+    lg: (min: 1.25rem, max: 1.375rem),
+    xl: (min: 1.5rem, max: 1.625rem),
+    "2xl": (min: 1.875rem, max: 2.2rem),
+    "3xl": (min: 2.25rem, max: 2.8rem),
+    "4xl": (min: 2.75rem, max: 3.5rem),
   ),
   type-base: (
     small: 3.8vw,
@@ -67,9 +166,34 @@ $pier-theme-defaults: (
     large: 1.6,
     huge: 1.575,
   ),
-  heading-weight: 900,
-  fonts: null,
+  heading-weight: 800,
+  font-stack-display: ("Instrument Sans", "Segoe UI", sans-serif),
+  spacers: null,
+  radii: null,
   helpers: null,
+  borders: (
+    0: 0,
+    1: 1px,
+    2: 2px,
+  ),
+  breakpoints: (
+    small: 0px,
+    medium: 48rem,
+    large: 72rem,
+    huge: 96rem,
+    enormous: 120rem,
+  ),
+  vbreakpoints: (
+    small: 0px,
+    medium: 42rem,
+    large: 62rem,
+  ),
+  grid: null,
+  column-count: 12,
+  column-gutter: 84px,
+  global-width: null,
+  row-width: null,
+  type-base-rem: null,
   color-steps: (
     lighter: (
       lightness: 20%,
@@ -97,26 +221,129 @@ $pier-theme-defaults: (
   stack-default-gap: null,
   cluster-default-gap: null,
   cluster-align: center,
-  fluid-min-vw: null,
-  fluid-max-vw: null,
+  fluid-min-vw: 20rem,
+  fluid-max-vw: 96rem,
+  components: (),
 ) !default;
 
-$pier-theme-overrides: () !default;
-$pier-theme: map.deep-merge($pier-theme-defaults, $pier-theme-overrides) !default;
+$pier-theme-dark-defaults: map.deep-merge(
+  $pier-theme-defaults,
+  (
+    color-bg: #111111,
+    color-surface: #181818,
+    color-text: #f4f4f2,
+    color-muted: rgba(#f4f4f2, 0.65),
+    color-border: rgba(#f4f4f2, 0.2),
+    color-accent: #f0713f,
+    color-accent-contrast: #101010,
+    shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4),
+    shadow-md: 0 18px 32px rgba(0, 0, 0, 0.35),
+    shadow-lg: 0 28px 45px rgba(0, 0, 0, 0.4),
+    components: (
+      button: (
+        ghost-fg: #f0713f,
+        subtle-bg: rgba(#f0713f, 0.12),
+        disabled-bg: rgba(#ffffff, 0.04),
+        disabled-fg: rgba(#ffffff, 0.35),
+      ),
+      input: (
+        bg: #181818,
+        border: 1px solid rgba(#f4f4f2, 0.18),
+        border-muted: 1px solid rgba(#f4f4f2, 0.12),
+        filled-bg: rgba(#ffffff, 0.04),
+        disabled-bg: rgba(#ffffff, 0.06),
+        disabled-fg: rgba(#ffffff, 0.4),
+      ),
+      card: (
+        bg: #1e1e1e,
+        border: 1px solid rgba(#ffffff, 0.08),
+      ),
+      tooltip: (
+        bg: rgba(#050505, 0.92),
+        fg: #f4f4f2,
+      ),
+    ),
+  )
+) !default;
 
-@function theme-value($key, $fallback: null) {
-  @if map.has-key($pier-theme, $key) {
-    $value: map.get($pier-theme, $key);
+@function _inject-components($theme) {
+  @return map.merge($theme, (
+    components: _build-component-defaults($theme),
+  ));
+}
 
+$_pier-theme-internal: map.deep-merge($pier-theme-defaults, $pier-theme-overrides);
+$pier-theme: _inject-components($_pier-theme-internal) !default;
+
+$_pier-theme-dark-internal: map.deep-merge($pier-theme-dark-defaults, $pier-theme-dark-overrides);
+$pier-theme-dark: _inject-components($_pier-theme-dark-internal) !default;
+
+@function theme-value($key, $fallback: null, $theme: $pier-theme) {
+  @if map.has-key($theme, $key) {
+    $value: map.get($theme, $key);
     @if $value != null {
       @return $value;
     }
   }
 
-  @if map.has-key($pier-theme-defaults, $key) {
-    @return map.get($pier-theme-defaults, $key);
+  @return $fallback;
+}
+
+@function theme-component($component, $key, $theme: $pier-theme, $fallback: null) {
+  $components: map.get($theme, components);
+
+  @if map.has-key($components, $component) {
+    $map: map.get($components, $component);
+    @if map.has-key($map, $key) {
+      @return map.get($map, $key);
+    }
   }
 
   @return $fallback;
 }
 
+@mixin pier-apply-theme($map, $selector: ":root") {
+  $line-heights: _fallback($map, line-heights, ());
+  $type-scale: _fallback($map, type-scale, ());
+
+  #{$selector} {
+    --pier-color-bg: #{_fallback($map, color-bg)};
+    --pier-color-surface: #{_fallback($map, color-surface, _fallback($map, color-bg))};
+    --pier-color-text: #{_fallback($map, color-text)};
+    --pier-color-muted: #{_fallback($map, color-muted, rgba(_fallback($map, color-text), 0.65))};
+    --pier-color-border: #{_fallback($map, color-border, rgba(_fallback($map, color-text), 0.18))};
+    --pier-color-accent: #{_fallback($map, color-accent)};
+    --pier-color-accent-contrast: #{_fallback($map, color-accent-contrast, #ffffff)};
+    --pier-color-success: #{_fallback($map, color-success, #2b8c62)};
+    --pier-color-warning: #{_fallback($map, color-warning, #b6721c)};
+    --pier-color-danger: #{_fallback($map, color-danger, #c23f3f)};
+    --pier-radius-base: #{_fallback($map, radius, 0.5rem)};
+    --pier-radius-lg: #{_fallback($map, radius-lg, _fallback($map, radius, 0.5rem) * 1.25)};
+    --pier-shadow-sm: #{_fallback($map, shadow-sm)};
+    --pier-shadow-md: #{_fallback($map, shadow-md)};
+    --pier-shadow-lg: #{_fallback($map, shadow-lg)};
+    --pier-space-unit: #{_fallback($map, space-unit, 0.5rem)};
+    --pier-font-base: #{meta.inspect(_fallback($map, font-stack))};
+    --pier-font-display: #{meta.inspect(_fallback($map, font-stack-display, _fallback($map, font-stack)))};
+    --pier-font-mono: #{meta.inspect(_fallback($map, font-mono, ("SFMono-Regular", monospace)))};
+    --pier-focus-ring-color: #{_fallback($map, color-accent)};
+  }
+
+  @each $name, $value in $line-heights {
+    #{$selector} {
+      --pier-line-#{$name}: #{$value};
+    }
+  }
+
+  @each $name, $scale in $type-scale {
+    $min: _fallback($scale, min, null);
+    $max: _fallback($scale, max, null);
+
+    #{$selector} {
+      --pier-type-#{$name}-min: #{$min};
+      --pier-type-#{$name}-max: #{$max};
+    }
+  }
+
+  @include component_tokens.pier-component-css-vars($map, $selector);
+}

--- a/src/pier/_tokens.scss
+++ b/src/pier/_tokens.scss
@@ -101,6 +101,16 @@
     }
 
     @if _should-output($targets, colors) {
+      --#{$prefix}-color-bg: #{config.$color-background};
+      --#{$prefix}-color-surface: #{config.$color-surface};
+      --#{$prefix}-color-text: #{config.$color-text};
+      --#{$prefix}-color-muted: #{config.$color-muted};
+      --#{$prefix}-color-border: #{config.$color-border};
+      --#{$prefix}-color-accent: #{config.$color-accent};
+      --#{$prefix}-color-accent-contrast: #{config.$color-accent-contrast};
+      --#{$prefix}-color-success: #{config.$color-success};
+      --#{$prefix}-color-warning: #{config.$color-warning};
+      --#{$prefix}-color-danger: #{config.$color-danger};
       @each $name, $token in config.$helpers {
         $tones: _color-tones($token);
 
@@ -123,6 +133,11 @@
       --#{$prefix}-stack-gap: #{_normalise-length(config.$stack-default-gap)};
       --#{$prefix}-cluster-gap: #{_normalise-length(config.$cluster-default-gap)};
       --#{$prefix}-cluster-align: #{config.$cluster-align};
+      --#{$prefix}-radius-base: #{config.$radius-base};
+      --#{$prefix}-radius-lg: #{config.$radius-lg};
+      --#{$prefix}-shadow-sm: #{config.$shadow-sm};
+      --#{$prefix}-shadow-md: #{config.$shadow-md};
+      --#{$prefix}-shadow-lg: #{config.$shadow-lg};
       @each $name, $value in config.$container-widths {
         #{_container-variable-name($prefix, $name)}: #{_normalise-length($value)};
       }

--- a/src/pier/_tooltips.scss
+++ b/src/pier/_tooltips.scss
@@ -1,0 +1,116 @@
+@use "sass:map";
+
+// -----------------------------------------------------------------------------
+// Tooltip pattern
+// -----------------------------------------------------------------------------
+
+$placements: (
+  top: (
+    inset: auto auto calc(100% + var(--pier-tooltip-offset, 0.5rem)) 50%,
+    translate: -50% calc(-1 * var(--pier-tooltip-offset, 0.5rem)),
+  ),
+  right: (
+    inset: 50% auto auto calc(100% + var(--pier-tooltip-offset, 0.5rem)),
+    translate: calc(var(--pier-tooltip-offset, 0.5rem)) -50%,
+  ),
+  bottom: (
+    inset: calc(100% + var(--pier-tooltip-offset, 0.5rem)) auto auto 50%,
+    translate: -50% var(--pier-tooltip-offset, 0.5rem),
+  ),
+  left: (
+    inset: 50% calc(100% + var(--pier-tooltip-offset, 0.5rem)) auto auto,
+    translate: calc(-1 * var(--pier-tooltip-offset, 0.5rem)) -50%,
+  ),
+) !default;
+
+[data-tooltip] {
+  position: relative;
+}
+
+[data-tooltip]::after,
+[data-tooltip]::before {
+  position: absolute;
+  left: 50%;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease;
+  pointer-events: none;
+}
+
+[data-tooltip]::after {
+  content: attr(data-tooltip);
+  background: var(--pier-tooltip-bg, rgba(17, 17, 17, 0.94));
+  color: var(--pier-tooltip-fg, #fff);
+  padding: var(--pier-tooltip-padding-y, 0.4rem) var(--pier-tooltip-padding-x, 0.6rem);
+  border-radius: var(--pier-tooltip-radius, 0.25rem);
+  box-shadow: var(--pier-tooltip-shadow, 0 10px 20px rgba(0, 0, 0, 0.2));
+  font-size: 0.875rem;
+  white-space: nowrap;
+  z-index: 20;
+}
+
+[data-tooltip]::before {
+  content: "";
+  border-width: 6px;
+  border-style: solid;
+  border-color: transparent;
+  z-index: 10;
+}
+
+[data-tooltip]:hover::after,
+[data-tooltip]:focus-visible::after,
+[data-tooltip]:hover::before,
+[data-tooltip]:focus-visible::before {
+  opacity: 1;
+  visibility: visible;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-tooltip]::after,
+  [data-tooltip]::before {
+    transition: none;
+  }
+}
+
+@each $placement, $settings in $placements {
+  $primary-axis: map.get($settings, inset);
+  $transform: map.get($settings, translate);
+
+  [data-tooltip],
+  [data-tooltip][data-tooltip-pos="#{$placement}"] {
+    &::after {
+      inset: #{$primary-axis};
+      transform: translate(#{$transform});
+    }
+
+    &::before {
+      inset: #{$primary-axis};
+      transform: translate(#{$transform});
+      border-#{$placement}-color: var(--pier-tooltip-bg, rgba(17, 17, 17, 0.94));
+    }
+  }
+}
+
+@mixin pier-tooltip($pos: top) {
+  position: relative;
+
+  &::after,
+  &::before {
+    position: absolute;
+  }
+
+  @if map.has-key($placements, $pos) {
+    $config: map.get($placements, $pos);
+
+    &::after {
+      inset: #{map.get($config, inset)};
+      transform: translate(#{map.get($config, translate)});
+    }
+
+    &::before {
+      inset: #{map.get($config, inset)};
+      transform: translate(#{map.get($config, translate)});
+      border-#{$pos}-color: var(--pier-tooltip-bg, rgba(17, 17, 17, 0.94));
+    }
+  }
+}

--- a/src/pier/_typography.roles.scss
+++ b/src/pier/_typography.roles.scss
@@ -1,0 +1,34 @@
+@use "sass:map";
+
+// -----------------------------------------------------------------------------
+// Typography roles
+// -----------------------------------------------------------------------------
+
+@mixin pier-text($size, $weight: null, $line: null, $tracking: null) {
+  font-size: clamp(
+    var(--pier-type-#{$size}-min, 1rem),
+    calc(var(--pier-type-#{$size}-min, 1rem) + 1vw),
+    var(--pier-type-#{$size}-max, 1.125rem)
+  );
+  font-weight: if($weight != null, $weight, inherit);
+  line-height: if($line != null, $line, var(--pier-line-base, 1.5));
+  letter-spacing: if($tracking != null, $tracking, normal);
+}
+
+.lead {
+  @include pier-text(lg, 500, var(--pier-line-relaxed, 1.7));
+  color: var(--pier-color-text);
+}
+
+.small {
+  @include pier-text(sm, null, var(--pier-line-snug, 1.4));
+}
+
+.muted {
+  color: var(--pier-color-muted);
+}
+
+.mono {
+  font-family: var(--pier-font-mono, monospace);
+  font-variant-ligatures: none;
+}

--- a/src/pier/_typography.scss
+++ b/src/pier/_typography.scss
@@ -1,9 +1,64 @@
+@use "sass:map";
+@use "config";
+@use "functions" as fn;
+@use "typography.roles" as roles;
+
 // -----------------------------------------------------------------------------
-// Typography helpers
-// -----------------------------------------------------------------------------
-// Convenience re-exports for the core typography mixins. Import via
-// `@use "pier/typography" as type;` to access `type.size()` and
-// `type.fluid-size()` without pulling in unrelated mixins.
+// Base typography
 // -----------------------------------------------------------------------------
 
-@forward "mixins" show scale, size, fluid-size, font-feature;
+body {
+  font-family: var(--pier-font-base, #{config.$font-stack});
+  line-height: var(--pier-line-base, #{map.get(config.$line-heights, base)});
+  color: var(--pier-color-text, #{config.$color-text});
+  background: var(--pier-color-bg, #{config.$color-background});
+  font-size: clamp(
+    var(--pier-type-md-min, 1rem),
+    calc(var(--pier-type-md-min, 1rem) + 0.2vw),
+    var(--pier-type-md-max, 1.0625rem)
+  );
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--pier-font-display, #{config.$font-stack-display});
+  font-weight: config.$heading-weight;
+  line-height: var(--pier-line-tight, #{map.get(config.$line-heights, tight)});
+  margin: 0 0 fn.spacer(3);
+}
+
+h1 { @include roles.pier-text(4xl, config.$heading-weight); }
+h2 { @include roles.pier-text(3xl, config.$heading-weight); }
+h3 { @include roles.pier-text(2xl, config.$heading-weight); }
+h4 { @include roles.pier-text(xl, config.$heading-weight); }
+h5 { @include roles.pier-text(lg, config.$heading-weight); }
+h6 { @include roles.pier-text(md, config.$heading-weight); }
+
+p {
+  margin: 0 0 fn.spacer(3);
+  line-height: var(--pier-line-base, #{map.get(config.$line-heights, base)});
+}
+
+ul,
+ol {
+  padding-left: fn.spacer(4);
+  margin: 0 0 fn.spacer(3);
+  line-height: inherit;
+}
+
+code,
+pre {
+  font-family: var(--pier-font-mono, #{config.$font-stack-mono});
+  background: var(--pier-color-surface, #{config.$color-surface});
+  padding: 0.2em 0.35em;
+  border-radius: var(--pier-radius-base, #{config.$radius-base});
+}
+
+pre {
+  padding: fn.spacer(3);
+  overflow-x: auto;
+}

--- a/src/pier/_utilities.align.scss
+++ b/src/pier/_utilities.align.scss
@@ -1,0 +1,28 @@
+// -----------------------------------------------------------------------------
+// Alignment utilities
+// -----------------------------------------------------------------------------
+
+@mixin pier-align-utilities() {
+  .flex { display: flex; }
+  .inline-flex { display: inline-flex; }
+  .grid { display: grid; }
+
+  .items-start { align-items: flex-start; }
+  .items-center { align-items: center; }
+  .items-end { align-items: flex-end; }
+  .justify-start { justify-content: flex-start; }
+  .justify-center { justify-content: center; }
+  .justify-between { justify-content: space-between; }
+  .justify-end { justify-content: flex-end; }
+  .content-center { align-content: center; }
+
+  .text-left { text-align: left; }
+  .text-center { text-align: center; }
+  .text-right { text-align: right; }
+
+  .wrap { flex-wrap: wrap; }
+  .nowrap { flex-wrap: nowrap; }
+
+  .inline-block { display: inline-block; }
+  .block { display: block; }
+}

--- a/src/pier/_utilities.scss
+++ b/src/pier/_utilities.scss
@@ -1,87 +1,20 @@
 @use "sass:map";
-@use "sass:meta";
-
 @use "config" as config;
 @use "grid";
 @use "layout";
 @use "mixins";
 @use "tokens";
+@use "utilities.spacing" as spacing_utilities;
+@use "utilities.align" as align_utilities;
+@use "utilities.sizing" as sizing_utilities;
 
 // -----------------------------------------------------------------------------
 // Utility generator
 // -----------------------------------------------------------------------------
-// Builds Pier's utility classes (spacing, colour, layout helpers) and wires in
-// responsive variants. `generate-utilities()` is invoked by the bundled entry
-// points, but can also be executed manually for custom scopes or prefixes.
-// -----------------------------------------------------------------------------
 
-$utility-config: (
-  border: (
-    module: mixins,
-    name: borders,
-  ),
-  margin: (
-    module: mixins,
-    name: margin,
-  ),
-  padding: (
-    module: mixins,
-    name: padding,
-  ),
-  radius: (
-    module: mixins,
-    name: radii,
-  ),
-  color: (
-    module: mixins,
-    name: colour-set,
-    args: (color),
-  ),
-  hover-color: (
-    module: mixins,
-    name: colour-set,
-    args: (hover, color),
-  ),
-  background: (
-    module: mixins,
-    name: colour-set,
-    args: (background-color),
-  ),
-  border-color: (
-    module: mixins,
-    name: colour-set,
-    args: (border-color),
-  ),
-  surface: (
-    module: mixins,
-    name: colour-set,
-    args: (background-color, (color contrast)),
-  ),
-  flow: (
-    module: layout,
-    name: stack,
-  ),
-  cluster: (
-    module: layout,
-    name: cluster,
-  ),
-  auto-grid: (
-    module: layout,
-    name: auto-grid,
-  ),
-  container: (
-    module: layout,
-    name: container,
-  ),
-);
-
-@mixin _call-utility($config) {
-  $module: map.get($config, module);
-  $name: map.get($config, name);
-  $args: if(map.has-key($config, args), map.get($config, args), ());
-
-  @include meta.call(meta.get-mixin($name, $module: $module), $args...);
-}
+$pier-include-spacing-utilities: true !default;
+$pier-include-align-utilities: true !default;
+$pier-include-sizing-utilities: true !default;
 
 @mixin _responsive-scope($breakpoint) {
   @include grid.breakpoint($breakpoint) {
@@ -91,20 +24,22 @@ $utility-config: (
   }
 }
 
-@mixin _utility-block() {
-  @each $name, $config in $utility-config {
-    &#{$name} {
-      @include _call-utility($config);
-    }
-  }
-}
-
 @mixin _base-utilities() {
-  @each $name, $config in $utility-config {
-    .#{$name} {
-      @include _call-utility($config);
-    }
-  }
+  .border { @include mixins.borders(); }
+  .margin { @include mixins.margin(); }
+  .padding { @include mixins.padding(); }
+  .radius { @include mixins.radii(); }
+
+  .color { @include mixins.colour-set(color); }
+  .hover-color { @include mixins.colour-set(hover, color); }
+  .background { @include mixins.colour-set(background-color); }
+  .border-color { @include mixins.colour-set(border-color); }
+  .surface { @include mixins.colour-set(background-color, (color contrast)); }
+
+  .flow { @include layout.stack(); }
+  .cluster { @include layout.cluster(); }
+  .auto-grid { @include layout.auto-grid(); }
+  .container { @include layout.container(); }
 }
 
 @mixin generate-utilities(
@@ -119,10 +54,22 @@ $utility-config: (
 
   @include _base-utilities();
 
+  @if $pier-include-spacing-utilities {
+    @include spacing_utilities.pier-spacing-utilities();
+  }
+
+  @if $pier-include-align-utilities {
+    @include align_utilities.pier-align-utilities();
+  }
+
+  @if $pier-include-sizing-utilities {
+    @include sizing_utilities.pier-sizing-utilities();
+  }
+
   @each $breakpoint, $settings in config.$grid {
     @if $breakpoint != small {
       @include _responsive-scope($breakpoint) {
-        @include _utility-block();
+        @include _base-utilities();
       }
     }
   }

--- a/src/pier/_utilities.sizing.scss
+++ b/src/pier/_utilities.sizing.scss
@@ -1,0 +1,33 @@
+@use "sass:map";
+@use "config";
+
+// -----------------------------------------------------------------------------
+// Sizing utilities
+// -----------------------------------------------------------------------------
+
+$widths: (
+  25: 25%,
+  50: 50%,
+  75: 75%,
+  100: 100%,
+) !default;
+
+@mixin pier-sizing-utilities($map: $widths) {
+  @each $key, $value in $map {
+    .w-#{$key} { width: $value; }
+  }
+
+  .w-auto { width: auto; }
+  .h-auto { height: auto; }
+  .h-100 { height: 100%; }
+
+  .max-w-prose { max-width: 65ch; }
+  .max-w-wide {
+    max-width: if(
+      map.has-key(config.$container-widths, wide),
+      map.get(config.$container-widths, wide),
+      92rem
+    );
+  }
+  .max-w-full { max-width: 100%; }
+}

--- a/src/pier/_utilities.spacing.scss
+++ b/src/pier/_utilities.spacing.scss
@@ -1,0 +1,49 @@
+@use "sass:map";
+@use "sass:meta";
+@use "config";
+
+// -----------------------------------------------------------------------------
+// Spacing utilities
+// -----------------------------------------------------------------------------
+
+$space-scale: config.$spacers !default;
+$axes: (
+  t: top,
+  r: right,
+  b: bottom,
+  l: left,
+  x: (left, right),
+  y: (top, bottom),
+) !default;
+$properties: (
+  m: margin,
+  p: padding,
+) !default;
+
+@mixin pier-spacing-utilities($map: $space-scale) {
+  @each $prefix, $property in $properties {
+    @each $key, $value in $map {
+      .#{$prefix}-#{$key} {
+        #{$property}: $value;
+      }
+
+      @each $axis, $targets in $axes {
+        .#{$prefix}#{$axis}-#{$key} {
+          @if meta.type-of($targets) == "list" {
+            @each $target in $targets {
+              #{$property}-#{$target}: $value;
+            }
+          } @else {
+            #{$property}-#{$targets}: $value;
+          }
+        }
+      }
+    }
+  }
+
+  @each $key, $value in $map {
+    .gap-#{$key} {
+      gap: $value;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a unified `@use "pier/_all"` entry that forwards the reset, tokens, layout primitives, utilities, and new component layers
- introduce component token mapping plus button, form, icon, typography, tooltip, and layout pattern updates backed by CSS variables and optional utilities
- refresh the documentation and demo to showcase theme toggling, layout patterns, utilities, and build scripts

## Testing
- npm run build:css
- npm run build:core
- npm run build:css:min

------
https://chatgpt.com/codex/tasks/task_e_68ff2b8551488332b99916c641f82bbb